### PR TITLE
Removing github token

### DIFF
--- a/.github/workflows/autolabel-prs.yml
+++ b/.github/workflows/autolabel-prs.yml
@@ -8,5 +8,3 @@ jobs:
 
     steps:
     - uses: actions/labeler@v2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Trying removing GITHUB_TOKEN for forked PRs.

Signed-off-by: ricardorames <ricardo.basilio@zup.com.br>