### PR TITLE
reduce resources and update images

### DIFF
--- a/install/helm-chart/Chart.yaml
+++ b/install/helm-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.1"
 description: CharlesCD chart
 name: Charles-CD
-version: 1.0.0
+version: 1.0.1

--- a/install/helm-chart/Readme.md
+++ b/install/helm-chart/Readme.md
@@ -16,8 +16,8 @@ This installation is recommended for who has already setup your infrastructure d
 | butler.image.pullPolicy                      | [documentation](https://kubernetes.io/docs/concepts/containers/images/)     | Always                                            |
 | butler.service.name                          | name of service in k8s                                                      | charlescd-butler                                  |
 | butler.service.type                          | type of service                                                             | ClusterIp                                         |
-| butler.resources.limits.cpu                  | max amount of CPU that a container can use                                  | 1                                                 |
-| butler.resources.limits.memory               | max amount of memory that a container can use                               | 1526Mi                                            |
+| butler.resources.limits.cpu                  | max amount of CPU that a container can use                                  | 128m                                              |
+| butler.resources.limits.memory               | max amount of memory that a container can use                               | 256Mi                                             |
 | butler.resources.requests.cpu                | min amount of CPU that a container needs to function                        | 128m                                              |
 | butler.resources.requests.memory             | min amount of memory that a container needs to function                     | 128Mi                                             |
 | moove.enabled                                | enable moove installation                                                   | true                                              |
@@ -34,7 +34,7 @@ This installation is recommended for who has already setup your infrastructure d
 | moove.service.name                           | name of service in k8s                                                      | charlescd-moove                                   |
 | moove.service.type                           | type of service                                                             | ClusterIp                                         |
 | moove.resources.limits.cpu                   | max amount of CPU that a container can use                                  | 1                                                 |
-| moove.resources.limits.memory                | max amount of memory that a container can use                               | 1526Mi                                            |
+| moove.resources.limits.memory                | max amount of memory that a container can use                               | 1024Mi                                            |
 | moove.resources.requests.cpu                 | min amount of CPU that a container needs to function                        | 128m                                              |
 | moove.resources.requests.memory              | min amount of memory that a container needs to function                     | 128Mi                                             |
 | villager.enabled                             | enable villager installation                                                | true                                              |
@@ -49,8 +49,8 @@ This installation is recommended for who has already setup your infrastructure d
 | villager.image.pullPolicy                    | [See documentation](https://kubernetes.io/docs/concepts/containers/images/) | Always                                            |
 | villager.service.name                        | name of villager service                                                    | charlescd-villager                                |
 | villager.service.type                        | type of villager service                                                    | ClusterIP                                         |
-| villager.resources.limits.cpu                | max amount of cpu that container can use                                    | 1                                                 |
-| villager.resources.limits.memory             | max memory to be used to run                                                | 1536Mi                                            |
+| villager.resources.limits.cpu                | max amount of cpu that container can use                                    | 256m                                              |
+| villager.resources.limits.memory             | max memory to be used to run                                                | 512Mi                                             |
 | villager.resources.requests.cpu              | minimum allocated amount of cpu that container can use                      | 128m                                              |
 | villager.resources.requests.memory           | minimum allocated amount of memmory that container can use                  | 128Mi                                             |
 | ui.enabled                                   | enable UI installation                                                      | true                                              |
@@ -62,10 +62,10 @@ This installation is recommended for who has already setup your infrastructure d
 | ui.image.pullPolicy                          | [See documentation](https://kubernetes.io/docs/concepts/containers/images/) | Always                                            |
 | ui.service.name                              | name of UI service                                                          | charlescd-ui                                      |
 | ui.service.type                              | type of UI service                                                          | ClusterIP                                         |
-| ui.resources.limits.cpu                      | max amount of cpu that container can use                                    | 1                                                 |
-| ui.resources.limits.memory                   | max memory to be used to run                                                | 1536Mi                                            |
-| ui.resources.requests.cpu                    | minimum allocated amount of cpu that container can use                      | 128m                                              |
-| ui.resources.requests.memory                 | minimum allocated amount of memmory that container can use                  | 128Mi                                             |
+| ui.resources.limits.cpu                      | max amount of cpu that container can use                                    | 127m                                              |
+| ui.resources.limits.memory                   | max memory to be used to run                                                | 128Mi                                             |
+| ui.resources.requests.cpu                    | minimum allocated amount of cpu that container can use                      | 64m                                               |
+| ui.resources.requests.memory                 | minimum allocated amount of memmory that container can use                  | 64Mi                                              |
 | circlematcher.enabled                        | enable Circle Matcher installation                                          | true                                              |
 | circlematcher.name                           | deployment name for Circle Matcher                                          | charlescd-circle-matcher                          |
 | circlematcher.redis.host                     | hostname of Redis instance                                                  | charlescd-redis-master                            |
@@ -77,8 +77,8 @@ This installation is recommended for who has already setup your infrastructure d
 | circlematcher.image.pullPolicy               | [See documentation](https://kubernetes.io/docs/concepts/containers/images/) | -                                                 |
 | circlematcher.service.name                   | name of Circle Matcher service                                              | charlescd-circle-matcher                          |
 | circlematcher.service.type                   | type of Circle Matcher service                                              | ClusterIP                                         |
-| circlematcher.resources.limits.cpu           | max amount of cpu that container can use                                    | 1                                                 |
-| circlematcher.resources.limits.memory        | max memory to be used to run                                                | 1536Mi                                            |
+| circlematcher.resources.limits.cpu           | max amount of cpu that container can use                                    | 256m                                              |
+| circlematcher.resources.limits.memory        | max memory to be used to run                                                | 256Mi                                             |
 | circlematcher.resources.requests.cpu         | minimum allocated amount of cpu that container can use                      | 128m                                              |
 | circlematcher.resources.requests.memory      | minimum allocated amount of memmory that container can use                  | 128Mi                                             |
 | keycloak.enabled                             | enable keycloak install                                                     | true                                              |

--- a/install/helm-chart/charts/octopipe-charlescd/Chart.yaml
+++ b/install/helm-chart/charts/octopipe-charlescd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Octopipe with k8s
 name: octopipe-charlescd
-version: 1.0.1
+version: 1.0.2

--- a/install/helm-chart/charts/octopipe-charlescd/values.yaml
+++ b/install/helm-chart/charts/octopipe-charlescd/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: octopipe
-  tag: zupcharles/charlescd-octopipe:0.2.1
+  tag: zupcharles/charlescd-octopipe:v0.2.11
   blueTag: latest
   pullPolicy: Always
 
@@ -42,8 +42,8 @@ ingress:
         - zup.lab.realwave.zup.me
 resources:
    limits:
-    cpu: 512m
-    memory: 512Mi
+    cpu: 256m
+    memory: 256Mi
    requests:
     cpu: 128m
     memory: 128Mi

--- a/install/helm-chart/single-file.yaml
+++ b/install/helm-chart/single-file.yaml
@@ -1054,7 +1054,7 @@ spec:
       
       containers:
         - name: octopipe
-          image: "zupcharles/charlescd-octopipe:0.2.1"
+          image: "zupcharles/charlescd-octopipe:v0.2.11"
           
           livenessProbe:
             failureThreshold: 3
@@ -1094,8 +1094,8 @@ spec:
                     
           resources:
             limits:
-              cpu: 512m
-              memory: 512Mi
+              cpu: 256m
+              memory: 256Mi
             requests:
               cpu: 128m
               memory: 128Mi
@@ -1131,7 +1131,7 @@ spec:
     spec:
       containers:
         - name: charlescd-butler
-          image: zupcharles/charlescd-butler:0.2.1
+          image: zupcharles/charlescd-butler:v0.2.10
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -1179,8 +1179,8 @@ spec:
                   key: encryption-key
           resources:
             limits:
-              cpu: 1
-              memory: 1536Mi
+              cpu: 128m
+              memory: 256Mi
             requests:
               cpu: 128m
               memory: 128Mi
@@ -1210,7 +1210,7 @@ spec:
     spec:
       containers:
         - name: charlescd-circle-matcher
-          image: zupcharles/charlescd-circle-matcher:0.2.2
+          image: zupcharles/charlescd-circle-matcher:v0.2.10
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -1242,11 +1242,11 @@ spec:
             - name: SPRING_REDIS_PASSWORD
               value: hb2Fj9MGKjBkZ6zV
             - name: ALLOWED_ORIGINS
-              value: http://34.68.141.223
+              value: http://charles.info.example
           resources:
             limits:
-              cpu: 1
-              memory: 1536Mi
+              cpu: 256m
+              memory: 256Mi
             requests:
               cpu: 128m
               memory: 128Mi
@@ -1276,7 +1276,7 @@ spec:
     spec:
       containers:
         - name: charlescd-moove
-          image: zupcharles/charlescd-moove:0.2.1
+          image: zupcharles/charlescd-moove:v0.2.10
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -1310,13 +1310,13 @@ spec:
             - name: KEYCLOCK_REALM
               value: "charlescd"
             - name: KEYCLOAK_SERVER_URL
-              value: "http://charlescd-keycloak-http/auth"
+              value: "http://charles.info.example/keycloak/auth"
             - name: KEYCLOAK_CLIENT_ID
               value: "realm-charlescd"
             - name: KEYCLOAK_CLIENT_SECRET
               value: "f2dc9337-9aaf-461f-9c7f-d02a0439ae4d"
             - name: ORIGIN_HOSTS
-              value: "http://localhost:3000,http://localhost:3001,http://localhost:8081,http://localhost:8080,http://34.68.141.223"
+              value: "http://localhost:3000,http://localhost:3001,http://localhost:8081,http://localhost:8080,http://charles.info.example"
             - name: ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
@@ -1355,7 +1355,7 @@ spec:
     spec:
       containers:
         - name: charlescd-ui
-          image: zupcharles/charlescd-ui:0.2.2
+          image: zupcharles/charlescd-ui:v0.2.10
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -1379,16 +1379,20 @@ spec:
           imagePullPolicy: Always
           env:
             - name: REACT_APP_API_URI
-              value: http://34.68.141.223
-            - name: REACT_APP_API_AUTH
-              value: http://34.68.141.223/keycloak/auth
+              value: http://charles.info.example
+            - name: REACT_APP_AUTH_URI
+              value: http://charles.info.example/keycloak
+            - name: REACT_APP_AUTH_REALM
+              value: charlescd
+            - name: REACT_APP_AUTH_CLIENT_ID
+              value: charlescd-client
           resources:
             limits:
-              cpu: 1
-              memory: 1536Mi
-            requests:
               cpu: 128m
               memory: 128Mi
+            requests:
+              cpu: 64m
+              memory: 64Mi
 ---
 # Source: Charles-CD/templates/charlescd-villager-deployment.yaml
 apiVersion: apps/v1
@@ -1415,7 +1419,7 @@ spec:
     spec:
       containers:
         - name: charlescd-villager
-          image: zupcharles/charlescd-villager:0.2.2
+          image: zupcharles/charlescd-villager:v0.2.10
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -1440,22 +1444,22 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "k8s"
-            - name: DARWIN_VILLAGER_DB_URI
+            - name: CHARLES_VILLAGER_DB_URI
               value: "jdbc:postgresql://charlescd-postgresql:5432/charlescd_villager"
-            - name: DARWIN_VILLAGER_DB_USERNAME
+            - name: CHARLES_VILLAGER_DB_USERNAME
               value: "charlescd_villager"
-            - name: DARWIN_VILLAGER_DB_PASSWORD
+            - name: CHARLES_VILLAGER_DB_PASSWORD
               value: "ZkQ67Lnhs2bM3MPN"
-            - name: DARWIN_BUILD_TIMEOUT
+            - name: CHARLES_BUILD_TIMEOUT
               value: "15"
-            - name: DARWIN_villager_ORGANIZATION
+            - name: CHARLES_villager_ORGANIZATION
               value: zup
             - name: CRYPT_KEY
               value: pvMPbPPNNB
           resources:
             limits:
-              cpu: 1
-              memory: 1536Mi
+              cpu: 256m
+              memory: 512Mi
             requests:
               cpu: 128m
               memory: 128Mi

--- a/install/helm-chart/templates/charlescd-moove-deployment.yaml
+++ b/install/helm-chart/templates/charlescd-moove-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: KEYCLOCK_REALM
               value: "charlescd"
             - name: KEYCLOAK_SERVER_URL
-              value: "http://{{ .Release.Name }}-keycloak-http/auth"
+              value: "{{ .Values.moove.keycloakHost}}"
             - name: KEYCLOAK_CLIENT_ID
               value: "realm-charlescd"
             - name: KEYCLOAK_CLIENT_SECRET

--- a/install/helm-chart/templates/charlescd-ui-deployment.yaml
+++ b/install/helm-chart/templates/charlescd-ui-deployment.yaml
@@ -48,8 +48,12 @@ spec:
           env:
             - name: REACT_APP_API_URI
               value: {{ .Values.ui.apiHost }}
-            - name: REACT_APP_API_AUTH
+            - name: REACT_APP_AUTH_URI
               value: {{ .Values.ui.keycloakHost }}
+            - name: REACT_APP_AUTH_REALM
+              value: charlescd
+            - name: REACT_APP_AUTH_CLIENT_ID
+              value: charlescd-client
           resources:
 {{ toYaml .Values.ui.resources | indent 12 }}
     {{- with .Values.ui.nodeSelector }}

--- a/install/helm-chart/templates/charlescd-villager-deployment.yaml
+++ b/install/helm-chart/templates/charlescd-villager-deployment.yaml
@@ -48,15 +48,15 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "k8s"
-            - name: DARWIN_VILLAGER_DB_URI
+            - name: CHARLES_VILLAGER_DB_URI
               value: "jdbc:postgresql://{{ .Values.villager.database.host}}:{{ .Values.villager.database.port }}/{{ .Values.villager.database.name}}"
-            - name: DARWIN_VILLAGER_DB_USERNAME
+            - name: CHARLES_VILLAGER_DB_USERNAME
               value: "{{ .Values.villager.database.user}}"
-            - name: DARWIN_VILLAGER_DB_PASSWORD
+            - name: CHARLES_VILLAGER_DB_PASSWORD
               value: "{{ .Values.villager.database.password}}"
-            - name: DARWIN_BUILD_TIMEOUT
+            - name: CHARLES_BUILD_TIMEOUT
               value: "15"
-            - name: DARWIN_villager_ORGANIZATION
+            - name: CHARLES_villager_ORGANIZATION
               value: zup
             - name: CRYPT_KEY
               value: pvMPbPPNNB

--- a/install/helm-chart/values.yaml
+++ b/install/helm-chart/values.yaml
@@ -9,7 +9,7 @@ butler:
     password: 3f2Yq8R4HhDCnefR
   replicaCount: 1
   image:
-    name: zupcharles/charlescd-butler:0.2.1
+    name: zupcharles/charlescd-butler:v0.2.10
     pullPolicy: Always
   service:
     name: charlescd-butler
@@ -19,8 +19,8 @@ butler:
         port: 3000
   resources:
    limits:
-    cpu: 1
-    memory: 1536Mi
+    cpu: 128m
+    memory: 256Mi
    requests:
     cpu: 128m
     memory: 128Mi
@@ -28,7 +28,8 @@ butler:
 moove:
   enabled: true
   name: "charlescd-moove"
-  frontHost: "http://34.68.141.223"
+  frontHost: "http://charles.info.example"
+  keycloakHost: "http://charles.info.example/keycloak/auth"
   database:
     name: charlescd_moove
     host: charlescd-postgresql
@@ -37,7 +38,7 @@ moove:
     password: 7Qs2KuM9gYzw48BS
   replicaCount: 1
   image:
-    name: zupcharles/charlescd-moove:0.2.1
+    name: zupcharles/charlescd-moove:v0.2.10
     pullPolicy: Always
   service:
     name: charlescd-moove
@@ -68,7 +69,7 @@ villager:
 
   replicaCount: 1
   image:
-    name: zupcharles/charlescd-villager:0.2.2
+    name: zupcharles/charlescd-villager:v0.2.10
     pullPolicy: Always
   service:
     name: charlescd-villager
@@ -78,8 +79,8 @@ villager:
       port: 8080
   resources:
    limits:
-    cpu: 1
-    memory: 1536Mi
+    cpu: 256m
+    memory: 512Mi
    requests:
     cpu: 128m
     memory: 128Mi   
@@ -87,11 +88,11 @@ villager:
 ui:
   enabled: true
   name: charlescd-ui
-  apiHost: http://34.68.141.223
-  keycloakHost: http://34.68.141.223/keycloak/auth
+  apiHost: http://charles.info.example
+  keycloakHost: http://charles.info.example/keycloak
   replicaCount: 1
   image:
-    name: zupcharles/charlescd-ui:0.2.2
+    name: zupcharles/charlescd-ui:v0.2.10
     pullPolicy: Always
   service:
     name: charlescd-ui
@@ -101,11 +102,11 @@ ui:
         port: 3000
   resources:
    limits:
-    cpu: 1
-    memory: 1536Mi
-   requests:
     cpu: 128m
     memory: 128Mi
+   requests:
+    cpu: 64m
+    memory: 64Mi
 
 circlematcher:
   enabled: true
@@ -114,10 +115,10 @@ circlematcher:
     host: charlescd-redis-master
     port: 6379
     password: hb2Fj9MGKjBkZ6zV
-  frontHost: http://34.68.141.223
+  frontHost: http://charles.info.example
   replicaCount: 1
   image:
-    name: zupcharles/charlescd-circle-matcher:0.2.2
+    name: zupcharles/charlescd-circle-matcher:v0.2.10
     pullPolicy: Always
   service:
     name: charlescd-circle-matcher
@@ -127,8 +128,8 @@ circlematcher:
         port: 8080
   resources:
    limits:
-    cpu: 1
-    memory: 1536Mi
+    cpu: 256m
+    memory: 256Mi
    requests:
     cpu: 128m
     memory: 128Mi


### PR DESCRIPTION
updating of the following modules:
- Octopipe (v0.2.11)
- UI (v0.2.10)
- Moove (v0.2.10)
- Butler (v0.2.10)
- Villager (v0.2.10)
- Circle-matcher (v0.2.10)

reduction of the standard resource quota of the charts. (now it is possible to run the CharlesCD on minikube with 5GB and 3vCPU)