### PR TITLE
POC/Discussion: dont use nest dependency injection on simples tests

### DIFF
--- a/butler/src/tests/unit/controllers/deployments-controller.spec.ts
+++ b/butler/src/tests/unit/controllers/deployments-controller.spec.ts
@@ -14,71 +14,31 @@
  * limitations under the License.
  */
 
-import { Test } from '@nestjs/testing'
 import { DeploymentsController } from '../../../app/api/deployments/controller'
-import { DeploymentsService } from '../../../app/api/deployments/services'
-import { DeploymentsServiceStub } from '../../stubs'
 import { ReadDeploymentDto } from '../../../app/api/deployments/dto'
+import { DeploymentsService } from '../../../app/api/deployments/services'
 import {
   CreateCircleDeploymentRequestUsecase,
   CreateDefaultDeploymentRequestUsecase,
   CreateUndeploymentRequestUsecase
 } from '../../../app/api/deployments/use-cases'
+import { DeploymentsServiceStub } from '../../stubs'
 import {
   CreateCircleDeploymentRequestUsecaseStub,
   CreateUndeploymentRequestUsecaseStub
 } from '../../stubs/use-cases'
-import {
-  ComponentsRepositoryStub,
-  DeploymentsRepositoryStub,
-  ModulesRepositoryStub
-} from '../../stubs/repository'
 
 describe('DeploymentsController', () => {
 
   let deploymentsController: DeploymentsController
-  let deploymentsService: DeploymentsService
+  let deploymentsService : DeploymentsService
 
   beforeEach(async() => {
-
-    const module = await Test.createTestingModule({
-      controllers: [
-        DeploymentsController
-      ],
-      providers: [
-        {
-          provide: DeploymentsService,
-          useClass: DeploymentsServiceStub
-        },
-        {
-          provide: CreateUndeploymentRequestUsecase,
-          useClass: CreateUndeploymentRequestUsecaseStub
-        },
-        {
-          provide: CreateCircleDeploymentRequestUsecase,
-          useClass: CreateCircleDeploymentRequestUsecaseStub
-        },
-        {
-          provide: CreateDefaultDeploymentRequestUsecase,
-          useClass: CreateCircleDeploymentRequestUsecaseStub
-        },
-        {
-          provide: 'DeploymentEntityRepository',
-          useClass: DeploymentsRepositoryStub
-        },
-        {
-          provide: 'ModuleEntityRepository',
-          useClass: ModulesRepositoryStub
-        },
-        {
-          provide: 'ComponentEntityRepository',
-          useClass: ComponentsRepositoryStub
-        }
-      ]
-    }).compile()
-
-    deploymentsService = module.get<DeploymentsService>(DeploymentsService)
-    deploymentsController = module.get<DeploymentsController>(DeploymentsController)
+    deploymentsService = new DeploymentsServiceStub() as DeploymentsService
+    const undeploymentUseCase = new CreateUndeploymentRequestUsecaseStub() as CreateUndeploymentRequestUsecase
+    const createCircleDeploymentUseCase = new CreateCircleDeploymentRequestUsecaseStub() as CreateCircleDeploymentRequestUsecase
+    const createDefaultDeploymentUseCase = new CreateCircleDeploymentRequestUsecaseStub() as CreateDefaultDeploymentRequestUsecase
+    deploymentsController = new DeploymentsController(deploymentsService, undeploymentUseCase, createCircleDeploymentUseCase, createDefaultDeploymentUseCase)
   })
 
   describe('getDeployments', () => {

--- a/butler/src/tests/unit/use-cases/component-queue-usecase.spec.ts
+++ b/butler/src/tests/unit/use-cases/component-queue-usecase.spec.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
+import { GetComponentQueueUseCase } from '../../../app/api/components/use-cases/get-component-queue.usecase'
 import { ComponentDeploymentEntity, QueuedDeploymentEntity } from '../../../app/api/deployments/entity'
 import { QueuedPipelineStatusEnum } from '../../../app/api/deployments/enums'
-import { GetComponentQueueUseCase } from '../../../app/api/components/use-cases/get-component-queue.usecase'
-import { Test } from '@nestjs/testing'
 import { ComponentDeploymentsRepository, QueuedDeploymentsRepository } from '../../../app/api/deployments/repository'
 import { ComponentDeploymentsRepositoryStub, QueuedDeploymentsRepositoryStub } from '../../stubs/repository'
 
@@ -30,7 +29,18 @@ describe('execute', () => {
   let queuedDeployments: QueuedDeploymentEntity[]
 
   beforeEach(async() => {
+    queuedDeploymentsRepository = new QueuedDeploymentsRepositoryStub() as unknown as QueuedDeploymentsRepository
+    componentDeploymentsRepository = new ComponentDeploymentsRepositoryStub() as unknown as ComponentDeploymentsRepository
+    getComponentQueueUseCase = new GetComponentQueueUseCase(queuedDeploymentsRepository, componentDeploymentsRepository)
+  })
 
+  it('should return a list of dto queued pipelines', async() => {
+    componentDeployment = new ComponentDeploymentEntity(
+      'dummy-id',
+      'dummy-name',
+      'dummy-img-url',
+      'dummy-img-tag'
+    )
     queuedDeployments = [
       new QueuedDeploymentEntity(
         'dummy-id',
@@ -44,31 +54,6 @@ describe('execute', () => {
       )
     ]
 
-    componentDeployment = new ComponentDeploymentEntity(
-      'dummy-id',
-      'dummy-name',
-      'dummy-img-url',
-      'dummy-img-tag'
-    )
-
-    const module = await Test.createTestingModule({
-      providers: [GetComponentQueueUseCase,
-        {
-          provide: ComponentDeploymentsRepository,
-          useClass: ComponentDeploymentsRepositoryStub
-        },
-        {
-          provide: QueuedDeploymentsRepository,
-          useClass: QueuedDeploymentsRepositoryStub
-        }]
-    }).compile()
-
-    getComponentQueueUseCase = module.get<GetComponentQueueUseCase>(GetComponentQueueUseCase)
-    queuedDeploymentsRepository = module.get<QueuedDeploymentsRepository>(QueuedDeploymentsRepository)
-    componentDeploymentsRepository = module.get<ComponentDeploymentsRepository>(ComponentDeploymentsRepository)
-  })
-
-  it('should return a list of dto queued pipelines', async() => {
     jest.spyOn(componentDeploymentsRepository, 'findOne')
       .mockImplementation(() => Promise.resolve(componentDeployment))
     jest.spyOn(queuedDeploymentsRepository, 'getAllByComponentIdAscending')


### PR DESCRIPTION
Maybe we dont need to use nestjs IOC container on simples tests.
Its very simple to instantiate the tested class when it has just a few dependencies.