### PR TITLE
Fix invalid date deploy metrics

### DIFF
--- a/moove/metrics/src/main/kotlin/io/charlescd/moove/metrics/api/response/DeploymentMetricsRepresentation.kt
+++ b/moove/metrics/src/main/kotlin/io/charlescd/moove/metrics/api/response/DeploymentMetricsRepresentation.kt
@@ -59,7 +59,7 @@ data class DeploymentStatsInPeriodRepresentation(
     val total: Int,
     val averageTime: Long,
 
-    @JsonFormat(pattern = "MM-dd-yyyy")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     val period: LocalDate
 ) {
     companion object {
@@ -74,7 +74,7 @@ data class DeploymentStatsInPeriodRepresentation(
 data class DeploymentAverageTimeInPeriodRepresentation(
     val averageTime: Long,
 
-    @JsonFormat(pattern = "MM-dd-yyyy")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     val period: LocalDate
 ) {
     companion object {

--- a/ui/src/modules/Metrics/Deploys/__tests__/helpers.spec.ts
+++ b/ui/src/modules/Metrics/Deploys/__tests__/helpers.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { chartDateFormatter } from '../helpers';
+
+test('must formatte date for chart', () => {
+  expect(chartDateFormatter("2020-08-13")).toEqual("13-08-2020");
+});

--- a/ui/src/modules/Metrics/Deploys/helpers.ts
+++ b/ui/src/modules/Metrics/Deploys/helpers.ts
@@ -46,7 +46,7 @@ export const getAverageTimeSeries = (data: DeployMetricData) => [
 ];
 
 export const chartDateFormatter = (date: string) => {
-  return dayjs(date).format('DD/MM');
+  return dayjs(date, 'YYYY-MM-DD').format('DD-MM-YYYY');
 };
 
 export const getPlotOption = (deploySeries: Array<any>) => {


### PR DESCRIPTION
Change date format in deploy metrics for better compatibility in different browsers.

Fix: #284 

