### PR TITLE
Return semantic error in octopipe

### DIFF
--- a/octopipe/pkg/api/pipeline.go
+++ b/octopipe/pkg/api/pipeline.go
@@ -40,7 +40,6 @@ func (api *PipelineAPI) startPipeline(ctx *gin.Context) {
 
 	err := api.mozart.Start(deployment)
 
-
 	if err != "" {
 		ctx.JSON(400, gin.H{ "message": err })
 	}else{

--- a/octopipe/pkg/api/pipeline.go
+++ b/octopipe/pkg/api/pipeline.go
@@ -38,7 +38,12 @@ func (api *PipelineAPI) startPipeline(ctx *gin.Context) {
 	var deployment *deployment.Deployment
 	ctx.Bind(&deployment)
 
-	api.mozart.Start(deployment)
+	err := api.mozart.Start(deployment)
 
-	ctx.JSON(201, nil)
+
+	if err != "" {
+		ctx.JSON(400, gin.H{ "message": err })
+	}else{
+		ctx.JSON(201, nil)
+	}
 }

--- a/octopipe/pkg/api/pipeline.go
+++ b/octopipe/pkg/api/pipeline.go
@@ -41,8 +41,8 @@ func (api *PipelineAPI) startPipeline(ctx *gin.Context) {
 	err := api.mozart.Start(deployment)
 
 	if err != "" {
-		ctx.JSON(400, gin.H{ "message": err })
-	}else{
+		ctx.JSON(400, gin.H{ "message" : err })
+	} else {
 		ctx.JSON(201, nil)
 	}
 }

--- a/octopipe/pkg/deployer/deployer_deploy.go
+++ b/octopipe/pkg/deployer/deployer_deploy.go
@@ -18,6 +18,7 @@ package deployer
 
 import (
 	"errors"
+	"octopipe/pkg/utils"
 	"os"
 	"strconv"
 	"time"
@@ -91,13 +92,18 @@ func (deploy *Deploy) createResource() error {
 	resource := k8sResource.Namespace(deploy.Namespace)
 
 	_, err = resource.Create(deploy.Manifest, metav1.CreateOptions{})
-
+	if err != nil {
+		utils.CustomLog("error", "createResource", err.Error())
+		return err
+	}
 	err = deploy.newResourceVerification(resource, resourceSchema)
 	if err != nil {
+		utils.CustomLog("error", "createResource", err.Error())
 		return err
 	}
 
 	if err != nil {
+		utils.CustomLog("error", "createResource", err.Error())
 		return err
 	}
 

--- a/octopipe/pkg/execution/execution.go
+++ b/octopipe/pkg/execution/execution.go
@@ -175,7 +175,7 @@ func (executionManager *ExecutionManager) ExecutionFinished(executionID *primiti
 		pipelineErrorMessage = errorObject.Error()
 	} else {
 		status = ExecutionFinished
-
+		pipelineErrorMessage = ""
 	}
 	query := bson.M{"_id": executionID}
 	updateData := bson.M{

--- a/octopipe/pkg/execution/execution.go
+++ b/octopipe/pkg/execution/execution.go
@@ -166,15 +166,16 @@ func (executionManager *ExecutionManager) ExecutionError(executionID *primitive.
 	return nil
 }
 
-func (executionManager *ExecutionManager) ExecutionFinished(executionID *primitive.ObjectID, pipelineError error) error {
+func (executionManager *ExecutionManager) ExecutionFinished(executionID *primitive.ObjectID, pipelineError chan error) error {
 	var status string
 	var pipelineErrorMessage string
 	if pipelineError != nil {
 		status = ExecutionFailed
-		pipelineErrorMessage = pipelineError.Error()
+		errorObject := <- pipelineError
+		pipelineErrorMessage = errorObject.Error()
 	} else {
 		status = ExecutionFinished
-		pipelineErrorMessage = ""
+
 	}
 	query := bson.M{"_id": executionID}
 	updateData := bson.M{

--- a/octopipe/pkg/execution/fake/execution.go
+++ b/octopipe/pkg/execution/fake/execution.go
@@ -51,7 +51,7 @@ func (executionManagr *ExecutionManagerFake) ExecutionError(executionID *primiti
 	panic("implement me")
 }
 
-func (executionManagr *ExecutionManagerFake) ExecutionFinished(executionID *primitive.ObjectID, pipelineError error) error {
+func (executionManagr *ExecutionManagerFake) ExecutionFinished(executionID *primitive.ObjectID, pipelineError chan error) error {
 	panic("implement me")
 }
 

--- a/octopipe/pkg/execution/manager.go
+++ b/octopipe/pkg/execution/manager.go
@@ -31,7 +31,7 @@ type ManagerUseCases interface {
 		executionID *primitive.ObjectID, step *pipeline.Step,
 	) (*primitive.ObjectID, error)
 	ExecutionError(executionID *primitive.ObjectID, pipelineError error) error
-	ExecutionFinished(executionID *primitive.ObjectID, pipelineError error) error
+	ExecutionFinished(executionID *primitive.ObjectID, ṕipelineError chan error ) error
 	UpdateExecutionStepStatus(executionID *primitive.ObjectID, stepID *primitive.ObjectID, status string) error
 }
 

--- a/octopipe/pkg/execution/manager.go
+++ b/octopipe/pkg/execution/manager.go
@@ -31,7 +31,7 @@ type ManagerUseCases interface {
 		executionID *primitive.ObjectID, step *pipeline.Step,
 	) (*primitive.ObjectID, error)
 	ExecutionError(executionID *primitive.ObjectID, pipelineError error) error
-	ExecutionFinished(executionID *primitive.ObjectID, ṕipelineError chan error ) error
+	ExecutionFinished(executionID *primitive.ObjectID, ṕipelineError chan error) error
 	UpdateExecutionStepStatus(executionID *primitive.ObjectID, stepID *primitive.ObjectID, status string) error
 }
 

--- a/octopipe/pkg/execution/manager.go
+++ b/octopipe/pkg/execution/manager.go
@@ -31,7 +31,7 @@ type ManagerUseCases interface {
 		executionID *primitive.ObjectID, step *pipeline.Step,
 	) (*primitive.ObjectID, error)
 	ExecutionError(executionID *primitive.ObjectID, pipelineError error) error
-	ExecutionFinished(executionID *primitive.ObjectID, ṕipelineError chan error) error
+	ExecutionFinished(executionID *primitive.ObjectID, pipelineError chan error) error
 	UpdateExecutionStepStatus(executionID *primitive.ObjectID, stepID *primitive.ObjectID, status string) error
 }
 

--- a/octopipe/pkg/mozart/manager.go
+++ b/octopipe/pkg/mozart/manager.go
@@ -26,7 +26,7 @@ import (
 )
 
 type MozartUseCases interface {
-	Start(deployment *deployment.Deployment)
+	Start(deployment *deployment.Deployment) string
 }
 
 type MozartManager struct {
@@ -52,7 +52,8 @@ func NewMozartManager(execution execution.ManagerUseCases,
 	}
 }
 
-func (mozartManager *MozartManager) Start(deployment *deployment.Deployment) {
+func (mozartManager *MozartManager) Start(deployment *deployment.Deployment) string {
 	pipeline := NewMozart(mozartManager, deployment)
-	pipeline.Do(deployment)
+	err := pipeline.Do(deployment)
+	return err
 }

--- a/octopipe/pkg/mozart/mozart.go
+++ b/octopipe/pkg/mozart/mozart.go
@@ -53,13 +53,13 @@ func NewMozart(mozartManager *MozartManager, deployment *deployment.Deployment) 
 
 // TODO: Remove deployment param
 func (mozart *Mozart) Do(deployment *deployment.Deployment) string {
-	errors := make(chan error, 1)
+	errors := make(chan error)
 	go mozart.asyncStartPipeline(deployment, errors)
 	errObject := <- errors
 	return errObject.Error()
 }
 
-func (mozart *Mozart) asyncStartPipeline(deployment *deployment.Deployment,errors chan error)  {
+func (mozart *Mozart) asyncStartPipeline(deployment *deployment.Deployment, errors chan error)  {
 	var err error
 
 	mozart.CurrentExecutionID, err = mozart.executions.Create()

--- a/octopipe/pkg/mozart/mozart.go
+++ b/octopipe/pkg/mozart/mozart.go
@@ -68,7 +68,6 @@ func (mozart *Mozart) asyncStartPipeline(deployment *deployment.Deployment,error
 	}
 
 	for _, steps := range mozart.Stages {
-
 		if len(steps) <= 0 {
 			continue
 		}
@@ -82,7 +81,6 @@ func (mozart *Mozart) asyncStartPipeline(deployment *deployment.Deployment,error
 	}
 
 	mozart.finishPipeline(deployment, errors)
-
 }
 
 func (mozart *Mozart) executeSteps(steps []*pipeline.Step) error {

--- a/octopipe/pkg/mozart/mozart.go
+++ b/octopipe/pkg/mozart/mozart.go
@@ -54,7 +54,7 @@ func NewMozart(mozartManager *MozartManager, deployment *deployment.Deployment) 
 // TODO: Remove deployment param
 func (mozart *Mozart) Do(deployment *deployment.Deployment) string {
 	errors := make(chan error, 1)
-	go mozart.asyncStartPipeline(deployment,errors)
+	go mozart.asyncStartPipeline(deployment, errors)
 	errObject := <- errors
 	return errObject.Error()
 }


### PR DESCRIPTION
## Issue 
Octopipe was not returning a semantic error when a namespace wasn't found because an error was not verified and returned and because of this, that error was overrided
## Solution
Added a if for that error and log  and return that error in response

 