### PR TITLE
Change on click expand for a redirect to that circle

### DIFF
--- a/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
+++ b/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
@@ -19,7 +19,7 @@ import { useHistory } from 'react-router-dom';
 import Text from 'core/components/Text';
 import Styled from './styled';
 import { getStatus } from '../../helpers';
-import CircleReleasesTable from './CircleReleasesTable';
+// import CircleReleasesTable from './CircleReleasesTable';
 import { CircleHistory } from '../interfaces';
 import routes from 'core/constants/routes';
 import { humanizeDateFromSeconds, dateTimeFormatter } from 'core/utils/date';

--- a/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
+++ b/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
 import Text from 'core/components/Text';
 import Styled from './styled';
 import { getStatus } from '../../helpers';
 import CircleReleasesTable from './CircleReleasesTable';
 import { CircleHistory } from '../interfaces';
+import routes from 'core/constants/routes';
 import { humanizeDateFromSeconds, dateTimeFormatter } from 'core/utils/date';
 
 type Props = {
@@ -27,14 +29,18 @@ type Props = {
 };
 
 const CircleRow = ({ circle }: Props) => {
-  const [activeRow, setActiveRow] = useState(false);
+  const history = useHistory();
+  // const [activeRow, setActiveRow] = useState(false);
+  // Screen wasn't a lot of useful data
 
   return (
     <Styled.CircleRow>
       <Styled.StatusLine status={getStatus(circle?.status)} />
       <Styled.TableRow
-        onClick={() => setActiveRow(!activeRow)}
         data-testid={`circle-row-${circle.id}`}
+        onClick={() =>
+          history.push(`${routes.circlesComparation}?circle=${circle.id}`)
+        }
       >
         <Styled.TableColumn>
           <Text.h5 color="light">{circle.name}</Text.h5>
@@ -50,7 +56,7 @@ const CircleRow = ({ circle }: Props) => {
           </Text.h5>
         </Styled.TableColumn>
       </Styled.TableRow>
-      {activeRow && (
+      {false && (
         <Styled.ReleasesWrapper>
           <CircleReleasesTable circleId={circle.id} />
         </Styled.ReleasesWrapper>

--- a/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
+++ b/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
@@ -29,8 +29,6 @@ type Props = {
 
 const CircleRow = ({ circle }: Props) => {
   const history = useHistory();
-  // const [activeRow, setActiveRow] = useState(false);
-  // Screen wasn't a lot of useful data
 
   return (
     <Styled.CircleRow>
@@ -55,11 +53,6 @@ const CircleRow = ({ circle }: Props) => {
           </Text.h5>
         </Styled.TableColumn>
       </Styled.TableRow>
-      {/* {activeRow && (
-        <Styled.ReleasesWrapper>
-          <CircleReleasesTable circleId={circle.id} />
-        </Styled.ReleasesWrapper>
-      )} */}
     </Styled.CircleRow>
   );
 };

--- a/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
+++ b/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
@@ -56,11 +56,11 @@ const CircleRow = ({ circle }: Props) => {
           </Text.h5>
         </Styled.TableColumn>
       </Styled.TableRow>
-      {false && (
+      {/* {activeRow && (
         <Styled.ReleasesWrapper>
           <CircleReleasesTable circleId={circle.id} />
         </Styled.ReleasesWrapper>
-      )}
+      )} */}
     </Styled.CircleRow>
   );
 };

--- a/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
+++ b/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
@@ -22,6 +22,7 @@ import { getStatus } from '../../helpers';
 import { CircleHistory } from '../interfaces';
 import routes from 'core/constants/routes';
 import { humanizeDateFromSeconds, dateTimeFormatter } from 'core/utils/date';
+import { addParam } from 'core/utils/path';
 
 type Props = {
   circle: CircleHistory;
@@ -36,7 +37,7 @@ const CircleRow = ({ circle }: Props) => {
       <Styled.TableRow
         data-testid={`circle-row-${circle.id}`}
         onClick={() =>
-          history.push(`${routes.circlesComparation}?circle=${circle.id}`)
+          addParam('circle', routes.circlesComparation, history, circle.id)
         }
       >
         <Styled.TableColumn>

--- a/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
+++ b/ui/src/modules/Metrics/Circles/History/CircleRow.tsx
@@ -19,7 +19,6 @@ import { useHistory } from 'react-router-dom';
 import Text from 'core/components/Text';
 import Styled from './styled';
 import { getStatus } from '../../helpers';
-// import CircleReleasesTable from './CircleReleasesTable';
 import { CircleHistory } from '../interfaces';
 import routes from 'core/constants/routes';
 import { humanizeDateFromSeconds, dateTimeFormatter } from 'core/utils/date';

--- a/ui/src/modules/Metrics/Circles/History/__tests__/CircleRow.spec.tsx
+++ b/ui/src/modules/Metrics/Circles/History/__tests__/CircleRow.spec.tsx
@@ -42,19 +42,19 @@ test('render default ReleaseRow', () => {
   expect(screen.getByText('7 days')).toBeInTheDocument();
 });
 
-test('render active ReleaseRow and show releases table', async () => {
-  (fetch as FetchMock).mockResponseOnce(
-    JSON.stringify(circlesReleasesMock)
-  );
+// test('render active ReleaseRow and show releases table', async () => {
+//   (fetch as FetchMock).mockResponseOnce(
+//     JSON.stringify(circlesReleasesMock)
+//   );
 
-  render(
-    <CircleRow circle={{ ...circleHistoryMock, status: 'ACTIVE' }} />
-  );
+//   render(
+//     <CircleRow circle={{ ...circleHistoryMock, status: 'ACTIVE' }} />
+//   );
 
-  const tableRow = screen.getByTestId('circle-row-1');
-  fireEvent.click(tableRow);
+//   const tableRow = screen.getByTestId('circle-row-1');
+//   fireEvent.click(tableRow);
 
-  await wait();
+//   await wait();
 
-  expect(screen.getAllByText(/release /)).toHaveLength(2);
-});
+//   expect(screen.getAllByText(/release /)).toHaveLength(2);
+// });

--- a/ui/src/modules/Metrics/Circles/History/__tests__/CircleRow.spec.tsx
+++ b/ui/src/modules/Metrics/Circles/History/__tests__/CircleRow.spec.tsx
@@ -42,19 +42,19 @@ test('render default ReleaseRow', () => {
   expect(screen.getByText('7 days')).toBeInTheDocument();
 });
 
-// test('render active ReleaseRow and show releases table', async () => {
-//   (fetch as FetchMock).mockResponseOnce(
-//     JSON.stringify(circlesReleasesMock)
-//   );
+test('render active ReleaseRow and show releases table', async () => {
+  (fetch as FetchMock).mockResponseOnce(
+    JSON.stringify(circlesReleasesMock)
+  );
 
-//   render(
-//     <CircleRow circle={{ ...circleHistoryMock, status: 'ACTIVE' }} />
-//   );
+  render(
+    <CircleRow circle={{ ...circleHistoryMock, status: 'ACTIVE' }} />
+  );
 
-//   const tableRow = screen.getByTestId('circle-row-1');
-//   fireEvent.click(tableRow);
+  const tableRow = screen.getByTestId('circle-row-1');
+  fireEvent.click(tableRow);
 
-//   await wait();
+  await wait();
 
-//   expect(screen.getAllByText(/release /)).toHaveLength(2);
-// });
+  expect(screen.getByText('circle 1')).toBeInTheDocument();
+});


### PR DESCRIPTION
For an request to improve the circle details screen, we change the expand action for the redirect action. Now when you click to expand the circle you will be redirect to that circle on the circle screen.

Signed-off-by: bCatanant <bruno.catanant@zup.com.br>