### PR TITLE
New summary component

### DIFF
--- a/ui/src/core/assets/themes/index.ts
+++ b/ui/src/core/assets/themes/index.ts
@@ -46,6 +46,7 @@ import { dark as darkCircleMatcher } from './circleMatcher';
 import { dark as darkCircleSegmentation } from './circleSegmentation';
 import { dark as darkCheckbox } from './checkbox';
 import { dark as darkCircleGroupMetrics } from './circleGroupMetrics';
+import { dark as darkSummary } from './summary';
 import { zIndex } from '../zindex';
 
 const common = {
@@ -89,7 +90,8 @@ const dark = {
   circleMatcher: darkCircleMatcher,
   circleSegmentation: darkCircleSegmentation,
   checkbox: darkCheckbox,
-  circleGroupMetrics: darkCircleGroupMetrics
+  circleGroupMetrics: darkCircleGroupMetrics,
+  summary: darkSummary
 };
 
 export default {

--- a/ui/src/core/assets/themes/summary.ts
+++ b/ui/src/core/assets/themes/summary.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  COLOR_MOUNTAIN_MEADOW,
+  COLOR_FREE_SPEECH_BLUE,
+  COLOR_NEON_BLUE,
+  COLOR_RED_ORANGE
+} from 'core/assets/colors';
+
+export const light = {};
+
+export const dark = {
+  colors: {
+    green: COLOR_MOUNTAIN_MEADOW,
+    darkBlue: COLOR_FREE_SPEECH_BLUE,
+    lightBlue: COLOR_NEON_BLUE,
+    red: COLOR_RED_ORANGE
+  }
+};

--- a/ui/src/core/components/Summary/Item/index.tsx
+++ b/ui/src/core/components/Summary/Item/index.tsx
@@ -24,13 +24,11 @@ type Props = {
   name: string;
 };
 
-const SummaryItem = ({ name, color, className }: Props) => {
-  return (
-    <Styled.Item className={className} data-testid={`summary-${color}-${name}`}>
-      <Styled.Dot color={color} />
-      <Text.h5 color="dark">{name}</Text.h5>
-    </Styled.Item>
-  );
-};
+const SummaryItem = ({ name, color, className }: Props) => (
+  <Styled.Item className={className} data-testid={`summary-${color}-${name}`}>
+    <Styled.Dot color={color} />
+    <Text.h5 color="dark">{name}</Text.h5>
+  </Styled.Item>
+);
 
 export default SummaryItem;

--- a/ui/src/core/components/Summary/Item/index.tsx
+++ b/ui/src/core/components/Summary/Item/index.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import Text from 'core/components/Text';
+import Styled from './styled';
+
+type Props = {
+  className?: string;
+  color: string;
+  name: string;
+};
+
+const SummaryItem = ({ name, color, className }: Props) => {
+  return (
+    <Styled.Item className={className} data-testid={`summary-${color}-${name}`}>
+      <Styled.Dot color={color} />
+      <Text.h5 color="dark">{name}</Text.h5>
+    </Styled.Item>
+  );
+};
+
+export default SummaryItem;

--- a/ui/src/core/components/Summary/Item/styled.tsx
+++ b/ui/src/core/components/Summary/Item/styled.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from 'styled-components';
+
+interface Dot {
+  color: string;
+}
+
+const Item = styled.div`
+  display: flex;
+  margin-right: 15px;
+`;
+
+const Dot = styled.div<Dot>`
+  height: 16px;
+  width: 16px;
+  background-color: ${({ theme, color }) => theme.summary.colors[color]};
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 5px;
+`;
+
+export default {
+  Item,
+  Dot
+};

--- a/ui/src/core/components/Summary/__tests__/Summary.spec.tsx
+++ b/ui/src/core/components/Summary/__tests__/Summary.spec.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, wait, fireEvent, screen } from 'unit-test/testUtils';
+import Summary from '../';
+
+test('render Summary', async () => {
+  render(
+    <Summary>
+      <Summary.Item color="red" name="Summary test 1"/>
+    </Summary>
+  );
+
+  const element = screen.getByTestId('summary');
+  expect(element).toBeInTheDocument();
+});
+
+test('render Summary with muilt items', async () => {
+  render(
+    <Summary>
+      <Summary.Item color="red" name="Summary test 1"/>
+      <Summary.Item color="darkBlue" name="Summary test 2"/>
+    </Summary>
+  );
+
+  const element = screen.getByTestId('summary');
+  const itemOne = screen.getByText('Summary test 1');
+  const itemTwo = screen.getByText('Summary test 2');
+  expect(element).toBeInTheDocument();
+  expect(itemOne).toBeInTheDocument();
+  expect(itemTwo).toBeInTheDocument();
+});

--- a/ui/src/core/components/Summary/index.tsx
+++ b/ui/src/core/components/Summary/index.tsx
@@ -23,13 +23,11 @@ type Props = {
   className?: string;
 };
 
-const Summary = ({ children, className }: Props) => {
-  return (
-    <Styled.Summary data-testid="summary" className={className}>
-      {children}
-    </Styled.Summary>
-  );
-};
+const Summary = ({ children, className }: Props) => (
+  <Styled.Summary data-testid="summary" className={className}>
+    {children}
+  </Styled.Summary>
+);
 
 Summary.Item = Item;
 

--- a/ui/src/core/components/Summary/index.tsx
+++ b/ui/src/core/components/Summary/index.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import Item from './Item';
+import Styled from './styled';
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+const Summary = ({ children, className }: Props) => {
+  return (
+    <Styled.Summary data-testid="summary" className={className}>
+      {children}
+    </Styled.Summary>
+  );
+};
+
+Summary.Item = Item;
+
+export default Summary;

--- a/ui/src/core/components/Summary/styled.ts
+++ b/ui/src/core/components/Summary/styled.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from 'styled-components';
+
+const Summary = styled.div`
+  display: flex;
+`;
+
+export default {
+  Summary
+};

--- a/ui/src/modules/Circles/Comparation/Item/Layer/MetricsGroups.tsx
+++ b/ui/src/modules/Circles/Comparation/Item/Layer/MetricsGroups.tsx
@@ -54,15 +54,23 @@ const LayerMetricsGroups = ({ onClickCreate, circleId }: Props) => {
 
       return (
         <Styled.MetricsGroupsCard key={metric?.id}>
-          <Styled.MetricsGroupsNameContent color={'light'} title={metric?.name}>
+          <Styled.MetricsGroupsNameContent
+            color={'light'}
+            title={metric?.name}
+            data-testid={`${metric.name}-group-name`}
+          >
             {metric?.name}
           </Styled.MetricsGroupsNameContent>
-          <Styled.MetricsGroupsCountContent color={'light'}>
+          <Styled.MetricsGroupsCountContent
+            color={'light'}
+            data-testid={`${metric.name}-group-count`}
+          >
             {metric.metricsCount}
           </Styled.MetricsGroupsCountContent>
           <Styled.MetricsGroupsThresholdsContent
             hasTreshold={metric.thresholds === 0}
             colorSVG={thresholdStatus.color}
+            data-testid={`${metric.name}-group-thresholds`}
           >
             {!(metric.thresholds === 0) && (
               <Icon

--- a/ui/src/modules/Circles/Comparation/Item/MetricsGroups/MetricsGroupCard/Metrics.tsx
+++ b/ui/src/modules/Circles/Comparation/Item/MetricsGroups/MetricsGroupCard/Metrics.tsx
@@ -51,12 +51,24 @@ const MetricCard = ({
   };
 
   return (
-    <Styled.MetricCardBody key={metric.id}>
-      <Styled.MetricNickname color="light" title={metric.nickname}>
+    <Styled.MetricCardBody
+      key={metric.id}
+      data-testid={`metric-group-card-${metric.nickname}`}
+    >
+      <Styled.MetricNickname
+        color="light"
+        title={metric.nickname}
+        data-testid={`${metric.nickname}-nickname`}
+      >
         {metric.nickname}
       </Styled.MetricNickname>
       <Styled.MetricConditionThreshold>
-        <Text.h5 color="dark">{getMetricCondition(metric.condition)}</Text.h5>
+        <Text.h5
+          color="dark"
+          data-testid={`${metric.nickname}-threshold-condition`}
+        >
+          {getMetricCondition(metric.condition)}
+        </Text.h5>
         <Text.h5 color="light" title={metric.threshold.toString()}>
           {metric.threshold !== 0 && metric.threshold}
         </Text.h5>
@@ -64,6 +76,7 @@ const MetricCard = ({
       <Styled.MetricLastValue
         color={thresholdStatus.color}
         hasTreshold={isEmpty(metric.condition)}
+        data-testid={`${metric.nickname}-threshold-last-value`}
       >
         <Icon
           name={thresholdStatus.icon}


### PR DESCRIPTION
If applyed, this PR will add `Summary` component:

![image](https://user-images.githubusercontent.com/51970701/95200124-3df66e00-07b4-11eb-960d-99581b476d79.png)

and some data-testid for testing