### PR TITLE
Remove old components when deploying on a circle (Override deployment)

### DIFF
--- a/.github/workflows/charlescd-prodrelease.yml
+++ b/.github/workflows/charlescd-prodrelease.yml
@@ -177,7 +177,7 @@ jobs:
 
     - run: yarn install
       working-directory: ./ui
-    - run: yarn build
+    - run: yarn build:all
       working-directory: ./ui
       env:
         CI: true

--- a/butler/src/app/v2/core/integrations/octopipe/request-builder.ts
+++ b/butler/src/app/v2/core/integrations/octopipe/request-builder.ts
@@ -123,6 +123,23 @@ export class OctopipeRequestBuilder {
     if (!deployment?.components) {
       return []
     }
+
+    if (deployment.defaultCircle) {
+      const unusedDeployments: OctopipeDeployment[] = []
+      deployment.components.forEach(component => {
+        const unusedComponent: Component | undefined = DeploymentUtils.getUnusedComponent(activeComponents, component, deployment.circleId)
+        if (unusedComponent) {
+          unusedDeployments.push({ //TODO improve this object later - It shouldnt be equal to the deployment object
+            componentName: unusedComponent.name,
+            helmRepositoryConfig: this.getHelmRepositoryConfig(unusedComponent, deployment.cdConfiguration),
+            helmConfig: this.getHelmConfig(unusedComponent, deployment.circleId),
+            rollbackIfFailed: false
+          })
+        }
+      })
+      return unusedDeployments
+
+    }
     return componentsToBeRemoved(deployment, activeComponents).map(component => {
       return {
         componentName: component.name,

--- a/butler/src/app/v2/core/integrations/spinnaker/pipeline-builder.ts
+++ b/butler/src/app/v2/core/integrations/spinnaker/pipeline-builder.ts
@@ -39,7 +39,7 @@ import {
 import { DeploymentTemplateUtils } from './utils/deployment-template.utils'
 import { UndeploymentTemplateUtils } from './utils/undeployment-template.utils'
 import { ConnectorConfiguration } from '../interfaces/connector-configuration.interface'
-import { DeploymentUtils } from '../utils/deployment.utils'
+import { componentsToBeRemoved, DeploymentUtils } from '../utils/deployment.utils'
 import { DeploymentComponent } from '../../../api/deployments/interfaces/deployment.interface'
 
 export class SpinnakerPipelineBuilder {
@@ -179,15 +179,10 @@ export class SpinnakerPipelineBuilder {
     if (!deployment?.components) {
       return []
     }
-    const stages: Stage[] = []
     const evalStageId: number = DeploymentTemplateUtils.getProxyEvalStageId(deployment.components)
-    deployment.components.forEach(component => {
-      const unusedComponent: Component | undefined = DeploymentUtils.getUnusedComponent(activeComponents, component, deployment.circleId)
-      if (unusedComponent) {
-        stages.push(getDeleteUnusedStage(unusedComponent, deployment.cdConfiguration, this.currentStageId++, evalStageId, deployment.circleId))
-      }
+    return componentsToBeRemoved(deployment, activeComponents).map(component => {
+      return getDeleteUnusedStage(component, deployment.cdConfiguration, this.currentStageId++, evalStageId, deployment.circleId)
     })
-    return stages
   }
 
   private getUndeploymentDeleteUnusedDeploymentsStage(deployment: Deployment): Stage[] {

--- a/butler/src/app/v2/core/integrations/spinnaker/pipeline-builder.ts
+++ b/butler/src/app/v2/core/integrations/spinnaker/pipeline-builder.ts
@@ -179,6 +179,19 @@ export class SpinnakerPipelineBuilder {
     if (!deployment?.components) {
       return []
     }
+
+    if (deployment.defaultCircle) {
+      const stages: Stage[] = []
+      const evalStageId: number = DeploymentTemplateUtils.getProxyEvalStageId(deployment.components)
+      deployment.components.forEach(component => {
+        const unusedComponent: Component | undefined = DeploymentUtils.getUnusedComponent(activeComponents, component, deployment.circleId)
+        if (unusedComponent) {
+          stages.push(getDeleteUnusedStage(unusedComponent, deployment.cdConfiguration, this.currentStageId++, evalStageId, deployment.circleId))
+        }
+      })
+      return stages
+    }
+
     const evalStageId: number = DeploymentTemplateUtils.getProxyEvalStageId(deployment.components)
     return componentsToBeRemoved(deployment, activeComponents).map(component => {
       return getDeleteUnusedStage(component, deployment.cdConfiguration, this.currentStageId++, evalStageId, deployment.circleId)

--- a/butler/src/app/v2/core/integrations/spinnaker/templates/deployment/delete-unused-stage.ts
+++ b/butler/src/app/v2/core/integrations/spinnaker/templates/deployment/delete-unused-stage.ts
@@ -16,10 +16,11 @@
 
 import { Stage } from '../../interfaces/spinnaker-pipeline.interface'
 import { ISpinnakerConfigurationData } from '../../../../../../v1/api/configurations/interfaces'
-import { CdConfiguration, Component } from '../../../../../api/deployments/interfaces'
+import { CdConfiguration } from '../../../../../api/deployments/interfaces'
+import { DeploymentComponent } from '../../../../../api/deployments/interfaces/deployment.interface'
 
 export const getDeleteUnusedStage = (
-  component: Component,
+  component: DeploymentComponent,
   configuration: CdConfiguration,
   stageId: number,
   evalStageId: number,

--- a/butler/src/app/v2/core/integrations/utils/deployment.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/deployment.utils.ts
@@ -15,7 +15,7 @@
  */
 
 import { Component } from '../../../api/deployments/interfaces'
-import { DeploymentComponent } from '../../../api/deployments/interfaces/deployment.interface'
+import { Deployment, DeploymentComponent } from '../../../api/deployments/interfaces/deployment.interface'
 
 const DeploymentUtils = {
   getActiveSameCircleTagComponent: (activeComponents: Component[], component: DeploymentComponent, circleId: string | null): Component | undefined => {
@@ -50,3 +50,39 @@ const DeploymentUtils = {
 }
 
 export { DeploymentUtils }
+
+
+export const componentsToBeRemoved = (deployment: Deployment, activeComponents: Component[]): DeploymentComponent[] => {
+  const circleId = deployment.circleId
+  return activeComponents.filter(c => {
+    return removedComponents(deployment.components, c, circleId) || updatedComponents(deployment.components, c, circleId)
+  })
+}
+
+const removedComponents = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
+  return !deploymentComponents?.some(dc => removedConditions(dc, activeComponent, circleId))
+}
+
+const updatedComponents = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
+  return deploymentComponents?.some(dc => updatedConditions(dc, activeComponent, circleId))
+}
+
+const removedConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
+  return isSameName(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
+}
+
+const updatedConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
+  return isSameNameAndDifferenteVersion(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
+}
+
+const isSameNameAndDifferenteVersion = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
+  return isSameName(deploymentComponent, activeComponent) && deploymentComponent.imageUrl !== activeComponent.imageUrl
+}
+
+const isSameName = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
+  return deploymentComponent.name === activeComponent.name
+}
+
+const isSameCircle = (circleId: string, deployment: Deployment): boolean => {
+  return circleId === deployment.circleId
+}

--- a/butler/src/app/v2/core/integrations/utils/deployment.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/deployment.utils.ts
@@ -76,7 +76,7 @@ const updatedConditions = (deploymentComponent: DeploymentComponent, activeCompo
 }
 
 const isSameNameAndDifferenteVersion = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
-  return isSameName(deploymentComponent, activeComponent) && deploymentComponent.imageUrl !== activeComponent.imageUrl
+  return isSameName(deploymentComponent, activeComponent) && deploymentComponent.imageTag !== activeComponent.imageTag
 }
 
 const isSameName = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {

--- a/butler/src/app/v2/core/integrations/utils/deployment.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/deployment.utils.ts
@@ -54,25 +54,26 @@ export { DeploymentUtils }
 
 export const componentsToBeRemoved = (deployment: Deployment, activeComponents: Component[]): DeploymentComponent[] => {
   const circleId = deployment.circleId
-  return activeComponents.filter(c => {
-    return removedComponents(deployment.components, c, circleId) || updatedComponents(deployment.components, c, circleId)
+  const sameCircleComponents = activeComponents.filter(c => c.deployment.circleId === circleId)
+  return sameCircleComponents.filter(c => {
+    return removedComponents(deployment.components, c) || updatedComponents(deployment.components, c)
   })
 }
 
-const removedComponents = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
-  return !deploymentComponents?.some(dc => removedConditions(dc, activeComponent, circleId))
+const removedComponents = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component) => {
+  return !deploymentComponents?.some(dc => removedConditions(dc, activeComponent))
 }
 
-const updatedComponents = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
-  return deploymentComponents?.some(dc => updatedConditions(dc, activeComponent, circleId))
+const updatedComponents = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component) => {
+  return deploymentComponents?.some(dc => updatedConditions(dc, activeComponent))
 }
 
-const removedConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
-  return isSameName(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
+const removedConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
+  return isSameName(deploymentComponent, activeComponent)
 }
 
-const updatedConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
-  return isSameNameAndDifferenteVersion(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
+const updatedConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
+  return isSameNameAndDifferenteVersion(deploymentComponent, activeComponent)
 }
 
 const isSameNameAndDifferenteVersion = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
@@ -81,8 +82,4 @@ const isSameNameAndDifferenteVersion = (deploymentComponent: DeploymentComponent
 
 const isSameName = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
   return deploymentComponent.name === activeComponent.name
-}
-
-const isSameCircle = (circleId: string, deployment: Deployment): boolean => {
-  return circleId === deployment.circleId
 }

--- a/butler/src/tests/v2/unit/octopipe/fixtures/deployment/complete-request-override.ts
+++ b/butler/src/tests/v2/unit/octopipe/fixtures/deployment/complete-request-override.ts
@@ -1,0 +1,507 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GitProvidersEnum } from '../../../../../../app/v1/core/integrations/configuration/interfaces/git-providers.type'
+import { OctopipeDeploymentRequest } from '../../../../../../app/v2/core/integrations/octopipe/interfaces/octopipe-deployment.interface'
+
+export const completeOctopipeDeploymentWithOverrides: OctopipeDeploymentRequest = {
+  namespace: 'sandbox',
+  deployments: [
+    {
+      componentName: 'A',
+      helmRepositoryConfig: {
+        type: GitProvidersEnum.GITHUB,
+        url: 'http://localhost:2222/helm',
+        token: 'git-token'
+      },
+      helmConfig: {
+        overrideValues: {
+          'image.tag': 'https://repository.com/A:v2',
+          deploymentName: 'A-v2-circle-id',
+          component: 'A',
+          tag: 'v2',
+          circleId: 'circle-id'
+        }
+      },
+      rollbackIfFailed: true
+    },
+    {
+      componentName: 'B',
+      helmRepositoryConfig: {
+        type: GitProvidersEnum.GITHUB,
+        url: 'http://localhost:2222/helm',
+        token: 'git-token'
+      },
+      helmConfig: {
+        overrideValues: {
+          'image.tag': 'https://repository.com/B:v2',
+          deploymentName: 'B-v2-circle-id',
+          component: 'B',
+          tag: 'v2',
+          circleId: 'circle-id'
+        }
+      },
+      rollbackIfFailed: true
+    },
+    {
+      componentName: 'C',
+      helmRepositoryConfig: {
+        type: GitProvidersEnum.GITHUB,
+        url: 'http://localhost:2222/helm',
+        token: 'git-token'
+      },
+      helmConfig: {
+        overrideValues: {
+          'image.tag': 'https://repository.com/C:v2',
+          deploymentName: 'C-v2-circle-id',
+          component: 'C',
+          tag: 'v2',
+          circleId: 'circle-id'
+        }
+      },
+      rollbackIfFailed: false
+    }
+  ],
+  unusedDeployments: [
+    {
+      componentName: 'A',
+      helmRepositoryConfig: {
+        type: GitProvidersEnum.GITHUB,
+        url: 'http://localhost:2222/helm',
+        token: 'git-token'
+      },
+      helmConfig: {
+        overrideValues: {
+          'image.tag': 'https://repository.com/A:v1',
+          deploymentName: 'A-v1-circle-id',
+          component: 'A',
+          tag: 'v1',
+          circleId: 'circle-id'
+        }
+      },
+      rollbackIfFailed: false
+    },
+    {
+      componentName: 'B',
+      helmRepositoryConfig: {
+        type: GitProvidersEnum.GITHUB,
+        url: 'http://localhost:2222/helm',
+        token: 'git-token'
+      },
+      helmConfig: {
+        overrideValues: {
+          'image.tag': 'https://repository.com/B:v1',
+          deploymentName: 'B-v1-circle-id',
+          component: 'B',
+          tag: 'v1',
+          circleId: 'circle-id'
+        }
+      },
+      rollbackIfFailed: false
+    }
+  ],
+  proxyDeployments: [
+    {
+      apiVersion: 'networking.istio.io/v1alpha3',
+      kind: 'DestinationRule',
+      metadata: {
+        name: 'A',
+        namespace: 'sandbox'
+      },
+      spec: {
+        host: 'A',
+        subsets: [
+          {
+            labels: {
+              component: 'A',
+              tag: 'v2',
+              circleId: 'circle-id'
+            },
+            name: 'circle-id'
+          },
+          {
+            labels: {
+              component: 'A',
+              tag: 'v0',
+              circleId: 'default-circle-id'
+            },
+            name: 'default-circle-id'
+          }
+        ]
+      }
+    },
+    {
+      apiVersion: 'networking.istio.io/v1alpha3',
+      kind: 'VirtualService',
+      metadata: {
+        name: 'A',
+        namespace: 'sandbox'
+      },
+      spec: {
+        gateways: [],
+        hosts: [
+          'A'
+        ],
+        http: [
+          {
+            match: [
+              {
+                headers: {
+                  cookie: {
+                    regex: '.*x-circle-id=circle-id.*'
+                  }
+                }
+              }
+            ],
+            route: [
+              {
+                destination: {
+                  host: 'A',
+                  subset: 'circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            match: [
+              {
+                headers: {
+                  'x-circle-id': {
+                    exact: 'circle-id'
+                  }
+                }
+              }
+            ],
+            route: [
+              {
+                destination: {
+                  host: 'A',
+                  subset: 'circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            route: [
+              {
+                destination: {
+                  host: 'A',
+                  subset: 'default-circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'default-circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'default-circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      apiVersion: 'networking.istio.io/v1alpha3',
+      kind: 'DestinationRule',
+      metadata: {
+        name: 'B',
+        namespace: 'sandbox'
+      },
+      spec: {
+        host: 'B',
+        subsets: [
+          {
+            labels: {
+              component: 'B',
+              tag: 'v2',
+              circleId: 'circle-id'
+            },
+            name: 'circle-id'
+          },
+          {
+            labels: {
+              component: 'B',
+              tag: 'v0',
+              circleId: 'default-circle-id'
+            },
+            name: 'default-circle-id'
+          }
+        ]
+      }
+    },
+    {
+      apiVersion: 'networking.istio.io/v1alpha3',
+      kind: 'VirtualService',
+      metadata: {
+        name: 'B',
+        namespace: 'sandbox'
+      },
+      spec: {
+        gateways: [],
+        hosts: [
+          'B'
+        ],
+        http: [
+          {
+            match: [
+              {
+                headers: {
+                  cookie: {
+                    regex: '.*x-circle-id=circle-id.*'
+                  }
+                }
+              }
+            ],
+            route: [
+              {
+                destination: {
+                  host: 'B',
+                  subset: 'circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            match: [
+              {
+                headers: {
+                  'x-circle-id': {
+                    exact: 'circle-id'
+                  }
+                }
+              }
+            ],
+            route: [
+              {
+                destination: {
+                  host: 'B',
+                  subset: 'circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            route: [
+              {
+                destination: {
+                  host: 'B',
+                  subset: 'default-circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'default-circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'default-circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      apiVersion: 'networking.istio.io/v1alpha3',
+      kind: 'DestinationRule',
+      metadata: {
+        name: 'C',
+        namespace: 'sandbox'
+      },
+      spec: {
+        host: 'C',
+        subsets: [
+          {
+            labels: {
+              component: 'C',
+              tag: 'v2',
+              circleId: 'circle-id'
+            },
+            name: 'circle-id'
+          },
+          {
+            labels: {
+              component: 'C',
+              tag: 'v0',
+              circleId: 'default-circle-id'
+            },
+            name: 'default-circle-id'
+          }
+        ]
+      }
+    },
+    {
+      apiVersion: 'networking.istio.io/v1alpha3',
+      kind: 'VirtualService',
+      metadata: {
+        name: 'C',
+        namespace: 'sandbox'
+      },
+      spec: {
+        gateways: [],
+        hosts: [
+          'C'
+        ],
+        http: [
+          {
+            match: [
+              {
+                headers: {
+                  cookie: {
+                    regex: '.*x-circle-id=circle-id.*'
+                  }
+                }
+              }
+            ],
+            route: [
+              {
+                destination: {
+                  host: 'C',
+                  subset: 'circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            match: [
+              {
+                headers: {
+                  'x-circle-id': {
+                    exact: 'circle-id'
+                  }
+                }
+              }
+            ],
+            route: [
+              {
+                destination: {
+                  host: 'C',
+                  subset: 'circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            route: [
+              {
+                destination: {
+                  host: 'C',
+                  subset: 'default-circle-id'
+                },
+                headers: {
+                  request: {
+                    set: {
+                      'x-circle-source': 'default-circle-id'
+                    }
+                  },
+                  response: {
+                    set: {
+                      'x-circle-source': 'default-circle-id'
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  callbackUrl: 'http://localhost:8883/butler/v2/executions/execution-id/notify',
+  clusterConfig: null
+}

--- a/butler/src/tests/v2/unit/octopipe/request-builder-deployment-override.spec.ts
+++ b/butler/src/tests/v2/unit/octopipe/request-builder-deployment-override.spec.ts
@@ -24,7 +24,7 @@ import { completeOctopipeDeploymentWithOverrides } from './fixtures/deployment/c
 
 describe('V2 Octopipe Deployment Request Builder', () => {
 
-  it('should create the correct complete request object with 3 new components and some unused components', async() => {
+  it('Should undeploy A:v1 and B:v1 but keep C:v2 when new deploy is A:v2, B:V2 and C:v2 and current components are A:v1, B:V1 and C:v2', async() => {
 
     const deploymentWith3Components: Deployment = {
       id: 'deployment-id',

--- a/butler/src/tests/v2/unit/octopipe/request-builder-deployment-override.spec.ts
+++ b/butler/src/tests/v2/unit/octopipe/request-builder-deployment-override.spec.ts
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'jest'
+import { CdTypeEnum } from '../../../../app/v1/api/configurations/enums'
+import { GitProvidersEnum } from '../../../../app/v1/core/integrations/configuration/interfaces/git-providers.type'
+import { ClusterProviderEnum } from '../../../../app/v1/core/integrations/octopipe/interfaces/octopipe-payload.interface'
+import { Component, Deployment } from '../../../../app/v2/api/deployments/interfaces'
+import { OctopipeRequestBuilder } from '../../../../app/v2/core/integrations/octopipe/request-builder'
+import { completeOctopipeDeploymentWithOverrides } from './fixtures/deployment/complete-request-override'
+
+describe('V2 Octopipe Deployment Request Builder', () => {
+
+  it('should create the correct complete request object with 3 new components and some unused components', async() => {
+
+    const deploymentWith3Components: Deployment = {
+      id: 'deployment-id',
+      authorId: 'user-1',
+      callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=1',
+      cdConfiguration: {
+        id: 'cd-configuration-id',
+        type: CdTypeEnum.OCTOPIPE,
+        configurationData: {
+          gitProvider: GitProvidersEnum.GITHUB,
+          gitToken: 'git-token',
+          provider: ClusterProviderEnum.DEFAULT,
+          namespace: 'sandbox'
+        },
+        name: 'octopipeconfiguration',
+        authorId: 'user-2',
+        workspaceId: 'workspace-id',
+        createdAt: new Date(),
+        deployments: null
+      },
+      defaultCircle: false,
+      circleId: 'circle-id',
+      createdAt: new Date(),
+      components: [
+        {
+          id: 'component-id-1',
+          helmUrl: 'http://localhost:2222/helm',
+          imageTag: 'v2',
+          imageUrl: 'https://repository.com/A:v2',
+          name: 'A',
+          running: false,
+          gatewayName: null,
+          hostValue: null
+        },
+        {
+          id: 'component-id-2',
+          helmUrl: 'http://localhost:2222/helm',
+          imageTag: 'v2',
+          imageUrl: 'https://repository.com/B:v2',
+          name: 'B',
+          running: false,
+          gatewayName: null,
+          hostValue: null
+        },
+        {
+          id: 'component-id-3',
+          helmUrl: 'http://localhost:2222/helm',
+          imageTag: 'v2',
+          imageUrl: 'https://repository.com/C:v2',
+          name: 'C',
+          running: false,
+          gatewayName: null,
+          hostValue: null
+        }
+      ]
+    }
+
+    const activeComponents: Component[] = [
+      {
+        id: 'component-id-4',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v1',
+        imageUrl: 'https://repository.com/A:v1',
+        name: 'A',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id4',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=4',
+          circleId: 'circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.OCTOPIPE,
+            configurationData: {
+              gitProvider: GitProvidersEnum.GITHUB,
+              gitToken: 'git-token',
+              provider: ClusterProviderEnum.DEFAULT,
+              namespace: 'sandbox'
+            },
+            name: 'octopipeconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: false
+        }
+      },
+      {
+        id: 'component-id-5',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v1',
+        imageUrl: 'https://repository.com/B:v1',
+        name: 'B',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id5',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=5',
+          circleId: 'circle-id',
+          defaultCircle: false,
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.OCTOPIPE,
+            configurationData: {
+              gitProvider: GitProvidersEnum.GITHUB,
+              gitToken: 'git-token',
+              provider: ClusterProviderEnum.DEFAULT,
+              namespace: 'sandbox'
+            },
+            name: 'octopipeconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          }
+        }
+      },
+      {
+        id: 'component-id-66',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v2',
+        imageUrl: 'https://repository.com/C:v2',
+        name: 'C',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'component-id-66',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=5',
+          circleId: 'circle-id',
+          defaultCircle: false,
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.OCTOPIPE,
+            configurationData: {
+              gitProvider: GitProvidersEnum.GITHUB,
+              gitToken: 'git-token',
+              provider: ClusterProviderEnum.DEFAULT,
+              namespace: 'sandbox'
+            },
+            name: 'octopipeconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          }
+        }
+      },
+      {
+        id: 'component-id-6',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v0',
+        imageUrl: 'https://repository.com/A:v0',
+        name: 'A',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id6',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=6',
+          circleId: 'default-circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.OCTOPIPE,
+            configurationData: {
+              gitProvider: GitProvidersEnum.GITHUB,
+              gitToken: 'git-token',
+              provider: ClusterProviderEnum.DEFAULT,
+              namespace: 'sandbox'
+            },
+            name: 'octopipeconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: true
+        }
+      },
+      {
+        id: 'component-id-7',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v0',
+        imageUrl: 'https://repository.com/B:v0',
+        name: 'B',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id7',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=7',
+          circleId: 'default-circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.OCTOPIPE,
+            configurationData: {
+              gitProvider: GitProvidersEnum.GITHUB,
+              gitToken: 'git-token',
+              provider: ClusterProviderEnum.DEFAULT,
+              namespace: 'sandbox'
+            },
+            name: 'octopipeconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: true
+        }
+      },
+      {
+        id: 'component-id-8',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v0',
+        imageUrl: 'https://repository.com/C:v0',
+        name: 'C',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id8',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=8',
+          circleId: 'default-circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.OCTOPIPE,
+            configurationData: {
+              gitProvider: GitProvidersEnum.GITHUB,
+              gitToken: 'git-token',
+              provider: ClusterProviderEnum.DEFAULT,
+              namespace: 'sandbox'
+            },
+            name: 'octopipeconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: true
+        }
+      }
+    ]
+
+    expect(
+      new OctopipeRequestBuilder().buildDeploymentRequest(deploymentWith3Components, activeComponents, { executionId: 'execution-id', incomingCircleId: 'Default' })
+    ).toEqual(completeOctopipeDeploymentWithOverrides)
+  })
+
+})

--- a/butler/src/tests/v2/unit/spinnaker/fixtures/deployment/deployment-complete-with-overrides.ts
+++ b/butler/src/tests/v2/unit/spinnaker/fixtures/deployment/deployment-complete-with-overrides.ts
@@ -1,0 +1,1236 @@
+export const completeWithOverrides = {
+  'application': 'app-cd-configuration-id',
+  'name': 'deployment-id',
+  'expectedArtifacts': [
+    {
+      'defaultArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'template-A-default-artifact',
+        'name': 'template-A',
+        'reference': 'http://localhost:2222/helm/A/A-darwin.tgz',
+        'type': 'github/file',
+        'version': 'master'
+      },
+      'displayName': 'template',
+      'id': 'template - A',
+      'matchArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'useless-template',
+        'name': 'template-A',
+        'type': 'github/file'
+      },
+      'useDefaultArtifact': true,
+      'usePriorArtifact': false
+    },
+    {
+      'defaultArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'value-A-default-artifact',
+        'name': 'value-A',
+        'reference': 'http://localhost:2222/helm/A/A.yaml',
+        'type': 'github/file',
+        'version': 'master'
+      },
+      'displayName': 'value',
+      'id': 'value - A',
+      'matchArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'useless-value',
+        'name': 'value-A',
+        'type': 'github/file'
+      },
+      'useDefaultArtifact': true,
+      'usePriorArtifact': false
+    },
+    {
+      'defaultArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'template-B-default-artifact',
+        'name': 'template-B',
+        'reference': 'http://localhost:2222/helm/B/B-darwin.tgz',
+        'type': 'github/file',
+        'version': 'master'
+      },
+      'displayName': 'template',
+      'id': 'template - B',
+      'matchArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'useless-template',
+        'name': 'template-B',
+        'type': 'github/file'
+      },
+      'useDefaultArtifact': true,
+      'usePriorArtifact': false
+    },
+    {
+      'defaultArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'value-B-default-artifact',
+        'name': 'value-B',
+        'reference': 'http://localhost:2222/helm/B/B.yaml',
+        'type': 'github/file',
+        'version': 'master'
+      },
+      'displayName': 'value',
+      'id': 'value - B',
+      'matchArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'useless-value',
+        'name': 'value-B',
+        'type': 'github/file'
+      },
+      'useDefaultArtifact': true,
+      'usePriorArtifact': false
+    },
+    {
+      'defaultArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'template-C-default-artifact',
+        'name': 'template-C',
+        'reference': 'http://localhost:2222/helm/C/C-darwin.tgz',
+        'type': 'github/file',
+        'version': 'master'
+      },
+      'displayName': 'template',
+      'id': 'template - C',
+      'matchArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'useless-template',
+        'name': 'template-C',
+        'type': 'github/file'
+      },
+      'useDefaultArtifact': true,
+      'usePriorArtifact': false
+    },
+    {
+      'defaultArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'value-C-default-artifact',
+        'name': 'value-C',
+        'reference': 'http://localhost:2222/helm/C/C.yaml',
+        'type': 'github/file',
+        'version': 'master'
+      },
+      'displayName': 'value',
+      'id': 'value - C',
+      'matchArtifact': {
+        'artifactAccount': 'github-artifact',
+        'id': 'useless-value',
+        'name': 'value-C',
+        'type': 'github/file'
+      },
+      'useDefaultArtifact': true,
+      'usePriorArtifact': false
+    }
+  ],
+  'stages': [
+    {
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'expectedArtifacts': [
+        {
+          'defaultArtifact': {
+            'customKind': true,
+            'id': 'useless - deployment - v2'
+          },
+          'displayName': 'deployment - v2',
+          'id': 'deployment - v2',
+          'matchArtifact': {
+            'id': 'useless - deployment - v2 - match',
+            'name': 'A-v2',
+            'type': 'embedded/base64'
+          },
+          'useDefaultArtifact': false,
+          'usePriorArtifact': false
+        }
+      ],
+      'failPipeline': false,
+      'inputArtifacts': [
+        {
+          'account': 'github-artifact',
+          'id': 'template - A'
+        },
+        {
+          'account': 'github-artifact',
+          'id': 'value - A'
+        }
+      ],
+      'name': 'Bake A v2',
+      'namespace': 'sandbox',
+      'outputName': 'A-v2',
+      'overrides': {
+        'image.tag': 'https://repository.com/A:v2',
+        'deploymentName': 'A-v2-circle-id',
+        'component': 'A',
+        'tag': 'v2',
+        'circleId': 'circle-id'
+      },
+      'refId': '1',
+      'requisiteStageRefIds': [],
+      'stageEnabled': {
+        'type': 'expression'
+      },
+      'templateRenderer': 'HELM2',
+      'type': 'bakeManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifestArtifactAccount': 'embedded-artifact',
+      'manifestArtifactId': 'deployment - v2',
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy A v2',
+      'refId': '2',
+      'requisiteStageRefIds': [
+        '1'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'artifact',
+      'stageEnabled': {
+        'expression': '${ #stage(\'Bake A v2\').status.toString() == \'SUCCEEDED\'}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'expectedArtifacts': [
+        {
+          'defaultArtifact': {
+            'customKind': true,
+            'id': 'useless - deployment - v2'
+          },
+          'displayName': 'deployment - v2',
+          'id': 'deployment - v2',
+          'matchArtifact': {
+            'id': 'useless - deployment - v2 - match',
+            'name': 'B-v2',
+            'type': 'embedded/base64'
+          },
+          'useDefaultArtifact': false,
+          'usePriorArtifact': false
+        }
+      ],
+      'failPipeline': false,
+      'inputArtifacts': [
+        {
+          'account': 'github-artifact',
+          'id': 'template - B'
+        },
+        {
+          'account': 'github-artifact',
+          'id': 'value - B'
+        }
+      ],
+      'name': 'Bake B v2',
+      'namespace': 'sandbox',
+      'outputName': 'B-v2',
+      'overrides': {
+        'image.tag': 'https://repository.com/B:v2',
+        'deploymentName': 'B-v2-circle-id',
+        'component': 'B',
+        'tag': 'v2',
+        'circleId': 'circle-id'
+      },
+      'refId': '3',
+      'requisiteStageRefIds': [],
+      'stageEnabled': {
+        'type': 'expression'
+      },
+      'templateRenderer': 'HELM2',
+      'type': 'bakeManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifestArtifactAccount': 'embedded-artifact',
+      'manifestArtifactId': 'deployment - v2',
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy B v2',
+      'refId': '4',
+      'requisiteStageRefIds': [
+        '3'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'artifact',
+      'stageEnabled': {
+        'expression': '${ #stage(\'Bake B v2\').status.toString() == \'SUCCEEDED\'}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'expectedArtifacts': [
+        {
+          'defaultArtifact': {
+            'customKind': true,
+            'id': 'useless - deployment - v2'
+          },
+          'displayName': 'deployment - v2',
+          'id': 'deployment - v2',
+          'matchArtifact': {
+            'id': 'useless - deployment - v2 - match',
+            'name': 'C-v2',
+            'type': 'embedded/base64'
+          },
+          'useDefaultArtifact': false,
+          'usePriorArtifact': false
+        }
+      ],
+      'failPipeline': false,
+      'inputArtifacts': [
+        {
+          'account': 'github-artifact',
+          'id': 'template - C'
+        },
+        {
+          'account': 'github-artifact',
+          'id': 'value - C'
+        }
+      ],
+      'name': 'Bake C v2',
+      'namespace': 'sandbox',
+      'outputName': 'C-v2',
+      'overrides': {
+        'image.tag': 'https://repository.com/C:v2',
+        'deploymentName': 'C-v2-circle-id',
+        'component': 'C',
+        'tag': 'v2',
+        'circleId': 'circle-id'
+      },
+      'refId': '5',
+      'requisiteStageRefIds': [],
+      'stageEnabled': {
+        'type': 'expression'
+      },
+      'templateRenderer': 'HELM2',
+      'type': 'bakeManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifestArtifactAccount': 'embedded-artifact',
+      'manifestArtifactId': 'deployment - v2',
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy C v2',
+      'refId': '6',
+      'requisiteStageRefIds': [
+        '5'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'artifact',
+      'stageEnabled': {
+        'expression': '${ #stage(\'Bake C v2\').status.toString() == \'SUCCEEDED\'}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifests': [
+        {
+          'apiVersion': 'networking.istio.io/v1alpha3',
+          'kind': 'DestinationRule',
+          'metadata': {
+            'name': 'A',
+            'namespace': 'sandbox'
+          },
+          'spec': {
+            'host': 'A',
+            'subsets': [
+              {
+                'labels': {
+                  'component': 'A',
+                  'tag': 'v2',
+                  'circleId': 'circle-id'
+                },
+                'name': 'circle-id'
+              },
+              {
+                'labels': {
+                  'component': 'A',
+                  'tag': 'v0',
+                  'circleId': 'default-circle-id'
+                },
+                'name': 'default-circle-id'
+              }
+            ]
+          }
+        }
+      ],
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy Destination Rules A',
+      'refId': '7',
+      'requisiteStageRefIds': [
+        '13'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'text',
+      'stageEnabled': {
+        'expression': '${deploymentResult}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifests': [
+        {
+          'apiVersion': 'networking.istio.io/v1alpha3',
+          'kind': 'VirtualService',
+          'metadata': {
+            'name': 'A',
+            'namespace': 'sandbox'
+          },
+          'spec': {
+            'gateways': [],
+            'hosts': [
+              'A'
+            ],
+            'http': [
+              {
+                'match': [
+                  {
+                    'headers': {
+                      'cookie': {
+                        'regex': '.*x-circle-id=circle-id.*'
+                      }
+                    }
+                  }
+                ],
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'A',
+                      'subset': 'circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                'match': [
+                  {
+                    'headers': {
+                      'x-circle-id': {
+                        'exact': 'circle-id'
+                      }
+                    }
+                  }
+                ],
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'A',
+                      'subset': 'circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'A',
+                      'subset': 'default-circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'default-circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'default-circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy Virtual Service A',
+      'refId': '8',
+      'requisiteStageRefIds': [
+        '7'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'text',
+      'stageEnabled': {
+        'expression': '${ #stage(\'Deploy Destination Rules A\').status.toString() == \'SUCCEEDED\'}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifests': [
+        {
+          'apiVersion': 'networking.istio.io/v1alpha3',
+          'kind': 'DestinationRule',
+          'metadata': {
+            'name': 'B',
+            'namespace': 'sandbox'
+          },
+          'spec': {
+            'host': 'B',
+            'subsets': [
+              {
+                'labels': {
+                  'component': 'B',
+                  'tag': 'v2',
+                  'circleId': 'circle-id'
+                },
+                'name': 'circle-id'
+              },
+              {
+                'labels': {
+                  'component': 'B',
+                  'tag': 'v0',
+                  'circleId': 'default-circle-id'
+                },
+                'name': 'default-circle-id'
+              }
+            ]
+          }
+        }
+      ],
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy Destination Rules B',
+      'refId': '9',
+      'requisiteStageRefIds': [
+        '13'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'text',
+      'stageEnabled': {
+        'expression': '${deploymentResult}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifests': [
+        {
+          'apiVersion': 'networking.istio.io/v1alpha3',
+          'kind': 'VirtualService',
+          'metadata': {
+            'name': 'B',
+            'namespace': 'sandbox'
+          },
+          'spec': {
+            'gateways': [],
+            'hosts': [
+              'B'
+            ],
+            'http': [
+              {
+                'match': [
+                  {
+                    'headers': {
+                      'cookie': {
+                        'regex': '.*x-circle-id=circle-id.*'
+                      }
+                    }
+                  }
+                ],
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'B',
+                      'subset': 'circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                'match': [
+                  {
+                    'headers': {
+                      'x-circle-id': {
+                        'exact': 'circle-id'
+                      }
+                    }
+                  }
+                ],
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'B',
+                      'subset': 'circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'B',
+                      'subset': 'default-circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'default-circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'default-circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy Virtual Service B',
+      'refId': '10',
+      'requisiteStageRefIds': [
+        '9'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'text',
+      'stageEnabled': {
+        'expression': '${ #stage(\'Deploy Destination Rules B\').status.toString() == \'SUCCEEDED\'}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifests': [
+        {
+          'apiVersion': 'networking.istio.io/v1alpha3',
+          'kind': 'DestinationRule',
+          'metadata': {
+            'name': 'C',
+            'namespace': 'sandbox'
+          },
+          'spec': {
+            'host': 'C',
+            'subsets': [
+              {
+                'labels': {
+                  'component': 'C',
+                  'tag': 'v2',
+                  'circleId': 'circle-id'
+                },
+                'name': 'circle-id'
+              },
+              {
+                'labels': {
+                  'component': 'C',
+                  'tag': 'v0',
+                  'circleId': 'default-circle-id'
+                },
+                'name': 'default-circle-id'
+              }
+            ]
+          }
+        }
+      ],
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy Destination Rules C',
+      'refId': '11',
+      'requisiteStageRefIds': [
+        '13'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'text',
+      'stageEnabled': {
+        'expression': '${deploymentResult}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'account': 'default',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'manifests': [
+        {
+          'apiVersion': 'networking.istio.io/v1alpha3',
+          'kind': 'VirtualService',
+          'metadata': {
+            'name': 'C',
+            'namespace': 'sandbox'
+          },
+          'spec': {
+            'gateways': [],
+            'hosts': [
+              'C'
+            ],
+            'http': [
+              {
+                'match': [
+                  {
+                    'headers': {
+                      'cookie': {
+                        'regex': '.*x-circle-id=circle-id.*'
+                      }
+                    }
+                  }
+                ],
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'C',
+                      'subset': 'circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                'match': [
+                  {
+                    'headers': {
+                      'x-circle-id': {
+                        'exact': 'circle-id'
+                      }
+                    }
+                  }
+                ],
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'C',
+                      'subset': 'circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                'route': [
+                  {
+                    'destination': {
+                      'host': 'C',
+                      'subset': 'default-circle-id'
+                    },
+                    'headers': {
+                      'request': {
+                        'set': {
+                          'x-circle-source': 'default-circle-id'
+                        }
+                      },
+                      'response': {
+                        'set': {
+                          'x-circle-source': 'default-circle-id'
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      'moniker': {
+        'app': 'default'
+      },
+      'name': 'Deploy Virtual Service C',
+      'refId': '12',
+      'requisiteStageRefIds': [
+        '11'
+      ],
+      'skipExpressionEvaluation': false,
+      'source': 'text',
+      'stageEnabled': {
+        'expression': '${ #stage(\'Deploy Destination Rules C\').status.toString() == \'SUCCEEDED\'}',
+        'type': 'expression'
+      },
+      'trafficManagement': {
+        'enabled': false,
+        'options': {
+          'enableTraffic': false,
+          'services': []
+        }
+      },
+      'type': 'deployManifest'
+    },
+    {
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failOnFailedExpressions': true,
+      'failPipeline': false,
+      'name': 'Evaluate deployments',
+      'refId': '13',
+      'requisiteStageRefIds': [
+        '2',
+        '4',
+        '6'
+      ],
+      'type': 'evaluateVariables',
+      'variables': [
+        {
+          'key': 'deploymentResult',
+          'value': '${#stage(\'Deploy A v2\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy B v2\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy C v2\').status.toString() == \'SUCCEEDED\'}'
+        }
+      ]
+    },
+    {
+      'failOnFailedExpressions': true,
+      'name': 'Evaluate proxy deployments',
+      'refId': '14',
+      'requisiteStageRefIds': [
+        '8',
+        '10',
+        '12'
+      ],
+      'type': 'evaluateVariables',
+      'variables': [
+        {
+          'key': 'proxyDeploymentsResult',
+          'value': '${#stage(\'Deploy Virtual Service A\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy Virtual Service B\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy Virtual Service C\').status.toString() == \'SUCCEEDED\'}'
+        }
+      ]
+    },
+    {
+      'account': 'default',
+      'app': 'app-cd-configuration-id',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'kinds': [
+        'deployment'
+      ],
+      'labelSelectors': {
+        'selectors': [
+          {
+            'key': 'component',
+            'kind': 'EQUALS',
+            'values': [
+              'A'
+            ]
+          },
+          {
+            'key': 'tag',
+            'kind': 'EQUALS',
+            'values': [
+              'v2'
+            ]
+          },
+          {
+            'key': 'circleId',
+            'kind': 'EQUALS',
+            'values': [
+              'circle-id'
+            ]
+          }
+        ]
+      },
+      'location': 'sandbox',
+      'mode': 'label',
+      'name': 'Delete Deployment A v2',
+      'options': {
+        'cascading': true
+      },
+      'refId': '15',
+      'requisiteStageRefIds': [
+        '13'
+      ],
+      'stageEnabled': {
+        'expression': '${!deploymentResult}',
+        'type': 'expression'
+      },
+      'type': 'deleteManifest'
+    },
+    {
+      'account': 'default',
+      'app': 'app-cd-configuration-id',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'kinds': [
+        'deployment'
+      ],
+      'labelSelectors': {
+        'selectors': [
+          {
+            'key': 'component',
+            'kind': 'EQUALS',
+            'values': [
+              'B'
+            ]
+          },
+          {
+            'key': 'tag',
+            'kind': 'EQUALS',
+            'values': [
+              'v2'
+            ]
+          },
+          {
+            'key': 'circleId',
+            'kind': 'EQUALS',
+            'values': [
+              'circle-id'
+            ]
+          }
+        ]
+      },
+      'location': 'sandbox',
+      'mode': 'label',
+      'name': 'Delete Deployment B v2',
+      'options': {
+        'cascading': true
+      },
+      'refId': '16',
+      'requisiteStageRefIds': [
+        '13'
+      ],
+      'stageEnabled': {
+        'expression': '${!deploymentResult}',
+        'type': 'expression'
+      },
+      'type': 'deleteManifest'
+    },
+    {
+      'account': 'default',
+      'app': 'app-cd-configuration-id',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'kinds': [
+        'deployment'
+      ],
+      'labelSelectors': {
+        'selectors': [
+          {
+            'key': 'component',
+            'kind': 'EQUALS',
+            'values': [
+              'A'
+            ]
+          },
+          {
+            'key': 'tag',
+            'kind': 'EQUALS',
+            'values': [
+              'v1'
+            ]
+          },
+          {
+            'key': 'circleId',
+            'kind': 'EQUALS',
+            'values': [
+              'circle-id'
+            ]
+          }
+        ]
+      },
+      'location': 'sandbox',
+      'mode': 'label',
+      'name': 'Delete Unused Deployment A v1',
+      'nameStage': 'Delete Deployments',
+      'options': {
+        'cascading': true
+      },
+      'refId': '17',
+      'requisiteStageRefIds': [
+        '14'
+      ],
+      'stageEnabled': {
+        'expression': '${proxyDeploymentsResult}',
+        'type': 'expression'
+      },
+      'type': 'deleteManifest'
+    },
+    {
+      'account': 'default',
+      'app': 'app-cd-configuration-id',
+      'cloudProvider': 'kubernetes',
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'failPipeline': false,
+      'kinds': [
+        'deployment'
+      ],
+      'labelSelectors': {
+        'selectors': [
+          {
+            'key': 'component',
+            'kind': 'EQUALS',
+            'values': [
+              'B'
+            ]
+          },
+          {
+            'key': 'tag',
+            'kind': 'EQUALS',
+            'values': [
+              'v1'
+            ]
+          },
+          {
+            'key': 'circleId',
+            'kind': 'EQUALS',
+            'values': [
+              'circle-id'
+            ]
+          }
+        ]
+      },
+      'location': 'sandbox',
+      'mode': 'label',
+      'name': 'Delete Unused Deployment B v1',
+      'nameStage': 'Delete Deployments',
+      'options': {
+        'cascading': true
+      },
+      'refId': '18',
+      'requisiteStageRefIds': [
+        '14'
+      ],
+      'stageEnabled': {
+        'expression': '${proxyDeploymentsResult}',
+        'type': 'expression'
+      },
+      'type': 'deleteManifest'
+    },
+    {
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'customHeaders': {
+        'x-circle-id': 'Default'
+      },
+      'failPipeline': false,
+      'method': 'POST',
+      'name': 'Trigger Failure Webhook',
+      'payload': {
+        'status': 'FAILED',
+        'type': 'DEPLOYMENT'
+      },
+      'refId': '19',
+      'requisiteStageRefIds': [
+        '13',
+        '14'
+      ],
+      'stageEnabled': {
+        'expression': '${ !deploymentResult || !proxyDeploymentsResult }',
+        'type': 'expression'
+      },
+      'statusUrlResolution': 'getMethod',
+      'type': 'webhook',
+      'url': 'http://localhost:8883/butler/v2/executions/execution-id/notify'
+    },
+    {
+      'completeOtherBranchesThenFail': false,
+      'continuePipeline': true,
+      'customHeaders': {
+        'x-circle-id': 'Default'
+      },
+      'failPipeline': false,
+      'method': 'POST',
+      'name': 'Trigger Success Webhook',
+      'payload': {
+        'status': 'SUCCEEDED',
+        'type': 'DEPLOYMENT'
+      },
+      'refId': '20',
+      'requisiteStageRefIds': [
+        '13',
+        '14'
+      ],
+      'stageEnabled': {
+        'expression': '${ deploymentResult && proxyDeploymentsResult }',
+        'type': 'expression'
+      },
+      'statusUrlResolution': 'getMethod',
+      'type': 'webhook',
+      'url': 'http://localhost:8883/butler/v2/executions/execution-id/notify'
+    }
+  ]
+}

--- a/butler/src/tests/v2/unit/spinnaker/fixtures/deployment/deployment-complete-with-overrides.ts
+++ b/butler/src/tests/v2/unit/spinnaker/fixtures/deployment/deployment-complete-with-overrides.ts
@@ -1,473 +1,493 @@
-export const completeWithOverrides = {
-  'application': 'app-cd-configuration-id',
-  'name': 'deployment-id',
-  'expectedArtifacts': [
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DeploymentStatusEnum } from '../../../../../../app/v1/api/deployments/enums'
+import { ExecutionTypeEnum } from '../../../../../../app/v2/api/deployments/enums'
+import { SpinnakerPipeline } from '../../../../../../app/v2/core/integrations/spinnaker/interfaces/spinnaker-pipeline.interface'
+
+export const completeWithOverrides : SpinnakerPipeline = {
+  application: 'app-cd-configuration-id',
+  name: 'deployment-id',
+  expectedArtifacts: [
     {
-      'defaultArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'template-A-default-artifact',
-        'name': 'template-A',
-        'reference': 'http://localhost:2222/helm/A/A-darwin.tgz',
-        'type': 'github/file',
-        'version': 'master'
+      defaultArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'template-A-default-artifact',
+        name: 'template-A',
+        reference: 'http://localhost:2222/helm/A/A-darwin.tgz',
+        type: 'github/file',
+        version: 'master'
       },
-      'displayName': 'template',
-      'id': 'template - A',
-      'matchArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'useless-template',
-        'name': 'template-A',
-        'type': 'github/file'
+      displayName: 'template',
+      id: 'template - A',
+      matchArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'useless-template',
+        name: 'template-A',
+        type: 'github/file'
       },
-      'useDefaultArtifact': true,
-      'usePriorArtifact': false
+      useDefaultArtifact: true,
+      usePriorArtifact: false
     },
     {
-      'defaultArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'value-A-default-artifact',
-        'name': 'value-A',
-        'reference': 'http://localhost:2222/helm/A/A.yaml',
-        'type': 'github/file',
-        'version': 'master'
+      defaultArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'value-A-default-artifact',
+        name: 'value-A',
+        reference: 'http://localhost:2222/helm/A/A.yaml',
+        type: 'github/file',
+        version: 'master'
       },
-      'displayName': 'value',
-      'id': 'value - A',
-      'matchArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'useless-value',
-        'name': 'value-A',
-        'type': 'github/file'
+      displayName: 'value',
+      id: 'value - A',
+      matchArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'useless-value',
+        name: 'value-A',
+        type: 'github/file'
       },
-      'useDefaultArtifact': true,
-      'usePriorArtifact': false
+      useDefaultArtifact: true,
+      usePriorArtifact: false
     },
     {
-      'defaultArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'template-B-default-artifact',
-        'name': 'template-B',
-        'reference': 'http://localhost:2222/helm/B/B-darwin.tgz',
-        'type': 'github/file',
-        'version': 'master'
+      defaultArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'template-B-default-artifact',
+        name: 'template-B',
+        reference: 'http://localhost:2222/helm/B/B-darwin.tgz',
+        type: 'github/file',
+        version: 'master'
       },
-      'displayName': 'template',
-      'id': 'template - B',
-      'matchArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'useless-template',
-        'name': 'template-B',
-        'type': 'github/file'
+      displayName: 'template',
+      id: 'template - B',
+      matchArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'useless-template',
+        name: 'template-B',
+        type: 'github/file'
       },
-      'useDefaultArtifact': true,
-      'usePriorArtifact': false
+      useDefaultArtifact: true,
+      usePriorArtifact: false
     },
     {
-      'defaultArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'value-B-default-artifact',
-        'name': 'value-B',
-        'reference': 'http://localhost:2222/helm/B/B.yaml',
-        'type': 'github/file',
-        'version': 'master'
+      defaultArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'value-B-default-artifact',
+        name: 'value-B',
+        reference: 'http://localhost:2222/helm/B/B.yaml',
+        type: 'github/file',
+        version: 'master'
       },
-      'displayName': 'value',
-      'id': 'value - B',
-      'matchArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'useless-value',
-        'name': 'value-B',
-        'type': 'github/file'
+      displayName: 'value',
+      id: 'value - B',
+      matchArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'useless-value',
+        name: 'value-B',
+        type: 'github/file'
       },
-      'useDefaultArtifact': true,
-      'usePriorArtifact': false
+      useDefaultArtifact: true,
+      usePriorArtifact: false
     },
     {
-      'defaultArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'template-C-default-artifact',
-        'name': 'template-C',
-        'reference': 'http://localhost:2222/helm/C/C-darwin.tgz',
-        'type': 'github/file',
-        'version': 'master'
+      defaultArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'template-C-default-artifact',
+        name: 'template-C',
+        reference: 'http://localhost:2222/helm/C/C-darwin.tgz',
+        type: 'github/file',
+        version: 'master'
       },
-      'displayName': 'template',
-      'id': 'template - C',
-      'matchArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'useless-template',
-        'name': 'template-C',
-        'type': 'github/file'
+      displayName: 'template',
+      id: 'template - C',
+      matchArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'useless-template',
+        name: 'template-C',
+        type: 'github/file'
       },
-      'useDefaultArtifact': true,
-      'usePriorArtifact': false
+      useDefaultArtifact: true,
+      usePriorArtifact: false
     },
     {
-      'defaultArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'value-C-default-artifact',
-        'name': 'value-C',
-        'reference': 'http://localhost:2222/helm/C/C.yaml',
-        'type': 'github/file',
-        'version': 'master'
+      defaultArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'value-C-default-artifact',
+        name: 'value-C',
+        reference: 'http://localhost:2222/helm/C/C.yaml',
+        type: 'github/file',
+        version: 'master'
       },
-      'displayName': 'value',
-      'id': 'value - C',
-      'matchArtifact': {
-        'artifactAccount': 'github-artifact',
-        'id': 'useless-value',
-        'name': 'value-C',
-        'type': 'github/file'
+      displayName: 'value',
+      id: 'value - C',
+      matchArtifact: {
+        artifactAccount: 'github-artifact',
+        id: 'useless-value',
+        name: 'value-C',
+        type: 'github/file'
       },
-      'useDefaultArtifact': true,
-      'usePriorArtifact': false
+      useDefaultArtifact: true,
+      usePriorArtifact: false
     }
   ],
-  'stages': [
+  stages: [
     {
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'expectedArtifacts': [
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      expectedArtifacts: [
         {
-          'defaultArtifact': {
-            'customKind': true,
-            'id': 'useless - deployment - v2'
+          defaultArtifact: {
+            customKind: true,
+            id: 'useless - deployment - v2'
           },
-          'displayName': 'deployment - v2',
-          'id': 'deployment - v2',
-          'matchArtifact': {
-            'id': 'useless - deployment - v2 - match',
-            'name': 'A-v2',
-            'type': 'embedded/base64'
+          displayName: 'deployment - v2',
+          id: 'deployment - v2',
+          matchArtifact: {
+            id: 'useless - deployment - v2 - match',
+            name: 'A-v2',
+            type: 'embedded/base64'
           },
-          'useDefaultArtifact': false,
-          'usePriorArtifact': false
+          useDefaultArtifact: false,
+          usePriorArtifact: false
         }
       ],
-      'failPipeline': false,
-      'inputArtifacts': [
+      failPipeline: false,
+      inputArtifacts: [
         {
-          'account': 'github-artifact',
-          'id': 'template - A'
+          account: 'github-artifact',
+          id: 'template - A'
         },
         {
-          'account': 'github-artifact',
-          'id': 'value - A'
+          account: 'github-artifact',
+          id: 'value - A'
         }
       ],
-      'name': 'Bake A v2',
-      'namespace': 'sandbox',
-      'outputName': 'A-v2',
-      'overrides': {
+      name: 'Bake A v2',
+      namespace: 'sandbox',
+      outputName: 'A-v2',
+      overrides: {
         'image.tag': 'https://repository.com/A:v2',
-        'deploymentName': 'A-v2-circle-id',
-        'component': 'A',
-        'tag': 'v2',
-        'circleId': 'circle-id'
+        deploymentName: 'A-v2-circle-id',
+        component: 'A',
+        tag: 'v2',
+        circleId: 'circle-id'
       },
-      'refId': '1',
-      'requisiteStageRefIds': [],
-      'stageEnabled': {
-        'type': 'expression'
+      refId: '1',
+      requisiteStageRefIds: [],
+      stageEnabled: {
+        type: 'expression'
       },
-      'templateRenderer': 'HELM2',
-      'type': 'bakeManifest'
+      templateRenderer: 'HELM2',
+      type: 'bakeManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifestArtifactAccount': 'embedded-artifact',
-      'manifestArtifactId': 'deployment - v2',
-      'moniker': {
-        'app': 'default'
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifestArtifactAccount: 'embedded-artifact',
+      manifestArtifactId: 'deployment - v2',
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy A v2',
-      'refId': '2',
-      'requisiteStageRefIds': [
+      name: 'Deploy A v2',
+      refId: '2',
+      requisiteStageRefIds: [
         '1'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'artifact',
-      'stageEnabled': {
-        'expression': '${ #stage(\'Bake A v2\').status.toString() == \'SUCCEEDED\'}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'artifact',
+      stageEnabled: {
+        expression: '${ #stage(\'Bake A v2\').status.toString() == \'SUCCEEDED\'}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'expectedArtifacts': [
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      expectedArtifacts: [
         {
-          'defaultArtifact': {
-            'customKind': true,
-            'id': 'useless - deployment - v2'
+          defaultArtifact: {
+            customKind: true,
+            id: 'useless - deployment - v2'
           },
-          'displayName': 'deployment - v2',
-          'id': 'deployment - v2',
-          'matchArtifact': {
-            'id': 'useless - deployment - v2 - match',
-            'name': 'B-v2',
-            'type': 'embedded/base64'
+          displayName: 'deployment - v2',
+          id: 'deployment - v2',
+          matchArtifact: {
+            id: 'useless - deployment - v2 - match',
+            name: 'B-v2',
+            type: 'embedded/base64'
           },
-          'useDefaultArtifact': false,
-          'usePriorArtifact': false
+          useDefaultArtifact: false,
+          usePriorArtifact: false
         }
       ],
-      'failPipeline': false,
-      'inputArtifacts': [
+      failPipeline: false,
+      inputArtifacts: [
         {
-          'account': 'github-artifact',
-          'id': 'template - B'
+          account: 'github-artifact',
+          id: 'template - B'
         },
         {
-          'account': 'github-artifact',
-          'id': 'value - B'
+          account: 'github-artifact',
+          id: 'value - B'
         }
       ],
-      'name': 'Bake B v2',
-      'namespace': 'sandbox',
-      'outputName': 'B-v2',
-      'overrides': {
+      name: 'Bake B v2',
+      namespace: 'sandbox',
+      outputName: 'B-v2',
+      overrides: {
         'image.tag': 'https://repository.com/B:v2',
-        'deploymentName': 'B-v2-circle-id',
-        'component': 'B',
-        'tag': 'v2',
-        'circleId': 'circle-id'
+        deploymentName: 'B-v2-circle-id',
+        component: 'B',
+        tag: 'v2',
+        circleId: 'circle-id'
       },
-      'refId': '3',
-      'requisiteStageRefIds': [],
-      'stageEnabled': {
-        'type': 'expression'
+      refId: '3',
+      requisiteStageRefIds: [],
+      stageEnabled: {
+        type: 'expression'
       },
-      'templateRenderer': 'HELM2',
-      'type': 'bakeManifest'
+      templateRenderer: 'HELM2',
+      type: 'bakeManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifestArtifactAccount': 'embedded-artifact',
-      'manifestArtifactId': 'deployment - v2',
-      'moniker': {
-        'app': 'default'
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifestArtifactAccount: 'embedded-artifact',
+      manifestArtifactId: 'deployment - v2',
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy B v2',
-      'refId': '4',
-      'requisiteStageRefIds': [
+      name: 'Deploy B v2',
+      refId: '4',
+      requisiteStageRefIds: [
         '3'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'artifact',
-      'stageEnabled': {
-        'expression': '${ #stage(\'Bake B v2\').status.toString() == \'SUCCEEDED\'}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'artifact',
+      stageEnabled: {
+        expression: '${ #stage(\'Bake B v2\').status.toString() == \'SUCCEEDED\'}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'expectedArtifacts': [
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      expectedArtifacts: [
         {
-          'defaultArtifact': {
-            'customKind': true,
-            'id': 'useless - deployment - v2'
+          defaultArtifact: {
+            customKind: true,
+            id: 'useless - deployment - v2'
           },
-          'displayName': 'deployment - v2',
-          'id': 'deployment - v2',
-          'matchArtifact': {
-            'id': 'useless - deployment - v2 - match',
-            'name': 'C-v2',
-            'type': 'embedded/base64'
+          displayName: 'deployment - v2',
+          id: 'deployment - v2',
+          matchArtifact: {
+            id: 'useless - deployment - v2 - match',
+            name: 'C-v2',
+            type: 'embedded/base64'
           },
-          'useDefaultArtifact': false,
-          'usePriorArtifact': false
+          useDefaultArtifact: false,
+          usePriorArtifact: false
         }
       ],
-      'failPipeline': false,
-      'inputArtifacts': [
+      failPipeline: false,
+      inputArtifacts: [
         {
-          'account': 'github-artifact',
-          'id': 'template - C'
+          account: 'github-artifact',
+          id: 'template - C'
         },
         {
-          'account': 'github-artifact',
-          'id': 'value - C'
+          account: 'github-artifact',
+          id: 'value - C'
         }
       ],
-      'name': 'Bake C v2',
-      'namespace': 'sandbox',
-      'outputName': 'C-v2',
-      'overrides': {
+      name: 'Bake C v2',
+      namespace: 'sandbox',
+      outputName: 'C-v2',
+      overrides: {
         'image.tag': 'https://repository.com/C:v2',
-        'deploymentName': 'C-v2-circle-id',
-        'component': 'C',
-        'tag': 'v2',
-        'circleId': 'circle-id'
+        deploymentName: 'C-v2-circle-id',
+        component: 'C',
+        tag: 'v2',
+        circleId: 'circle-id'
       },
-      'refId': '5',
-      'requisiteStageRefIds': [],
-      'stageEnabled': {
-        'type': 'expression'
+      refId: '5',
+      requisiteStageRefIds: [],
+      stageEnabled: {
+        type: 'expression'
       },
-      'templateRenderer': 'HELM2',
-      'type': 'bakeManifest'
+      templateRenderer: 'HELM2',
+      type: 'bakeManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifestArtifactAccount': 'embedded-artifact',
-      'manifestArtifactId': 'deployment - v2',
-      'moniker': {
-        'app': 'default'
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifestArtifactAccount: 'embedded-artifact',
+      manifestArtifactId: 'deployment - v2',
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy C v2',
-      'refId': '6',
-      'requisiteStageRefIds': [
+      name: 'Deploy C v2',
+      refId: '6',
+      requisiteStageRefIds: [
         '5'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'artifact',
-      'stageEnabled': {
-        'expression': '${ #stage(\'Bake C v2\').status.toString() == \'SUCCEEDED\'}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'artifact',
+      stageEnabled: {
+        expression: '${ #stage(\'Bake C v2\').status.toString() == \'SUCCEEDED\'}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifests': [
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifests: [
         {
-          'apiVersion': 'networking.istio.io/v1alpha3',
-          'kind': 'DestinationRule',
-          'metadata': {
-            'name': 'A',
-            'namespace': 'sandbox'
+          apiVersion: 'networking.istio.io/v1alpha3',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'A',
+            namespace: 'sandbox'
           },
-          'spec': {
-            'host': 'A',
-            'subsets': [
+          spec: {
+            host: 'A',
+            subsets: [
               {
-                'labels': {
-                  'component': 'A',
-                  'tag': 'v2',
-                  'circleId': 'circle-id'
+                labels: {
+                  component: 'A',
+                  tag: 'v2',
+                  circleId: 'circle-id'
                 },
-                'name': 'circle-id'
+                name: 'circle-id'
               },
               {
-                'labels': {
-                  'component': 'A',
-                  'tag': 'v0',
-                  'circleId': 'default-circle-id'
+                labels: {
+                  component: 'A',
+                  tag: 'v0',
+                  circleId: 'default-circle-id'
                 },
-                'name': 'default-circle-id'
+                name: 'default-circle-id'
               }
             ]
           }
         }
       ],
-      'moniker': {
-        'app': 'default'
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy Destination Rules A',
-      'refId': '7',
-      'requisiteStageRefIds': [
+      name: 'Deploy Destination Rules A',
+      refId: '7',
+      requisiteStageRefIds: [
         '13'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'text',
-      'stageEnabled': {
-        'expression': '${deploymentResult}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'text',
+      stageEnabled: {
+        expression: '${deploymentResult}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifests': [
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifests: [
         {
-          'apiVersion': 'networking.istio.io/v1alpha3',
-          'kind': 'VirtualService',
-          'metadata': {
-            'name': 'A',
-            'namespace': 'sandbox'
+          apiVersion: 'networking.istio.io/v1alpha3',
+          kind: 'VirtualService',
+          metadata: {
+            name: 'A',
+            namespace: 'sandbox'
           },
-          'spec': {
-            'gateways': [],
-            'hosts': [
+          spec: {
+            gateways: [],
+            hosts: [
               'A'
             ],
-            'http': [
+            http: [
               {
-                'match': [
+                match: [
                   {
-                    'headers': {
-                      'cookie': {
-                        'regex': '.*x-circle-id=circle-id.*'
+                    headers: {
+                      cookie: {
+                        regex: '.*x-circle-id=circle-id.*'
                       }
                     }
                   }
                 ],
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'A',
-                      'subset': 'circle-id'
+                    destination: {
+                      host: 'A',
+                      subset: 'circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       }
@@ -476,29 +496,29 @@ export const completeWithOverrides = {
                 ]
               },
               {
-                'match': [
+                match: [
                   {
-                    'headers': {
+                    headers: {
                       'x-circle-id': {
-                        'exact': 'circle-id'
+                        exact: 'circle-id'
                       }
                     }
                   }
                 ],
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'A',
-                      'subset': 'circle-id'
+                    destination: {
+                      host: 'A',
+                      subset: 'circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       }
@@ -507,20 +527,20 @@ export const completeWithOverrides = {
                 ]
               },
               {
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'A',
-                      'subset': 'default-circle-id'
+                    destination: {
+                      host: 'A',
+                      subset: 'default-circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'default-circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'default-circle-id'
                         }
                       }
@@ -532,133 +552,133 @@ export const completeWithOverrides = {
           }
         }
       ],
-      'moniker': {
-        'app': 'default'
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy Virtual Service A',
-      'refId': '8',
-      'requisiteStageRefIds': [
+      name: 'Deploy Virtual Service A',
+      refId: '8',
+      requisiteStageRefIds: [
         '7'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'text',
-      'stageEnabled': {
-        'expression': '${ #stage(\'Deploy Destination Rules A\').status.toString() == \'SUCCEEDED\'}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'text',
+      stageEnabled: {
+        expression: '${ #stage(\'Deploy Destination Rules A\').status.toString() == \'SUCCEEDED\'}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifests': [
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifests: [
         {
-          'apiVersion': 'networking.istio.io/v1alpha3',
-          'kind': 'DestinationRule',
-          'metadata': {
-            'name': 'B',
-            'namespace': 'sandbox'
+          apiVersion: 'networking.istio.io/v1alpha3',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'B',
+            namespace: 'sandbox'
           },
-          'spec': {
-            'host': 'B',
-            'subsets': [
+          spec: {
+            host: 'B',
+            subsets: [
               {
-                'labels': {
-                  'component': 'B',
-                  'tag': 'v2',
-                  'circleId': 'circle-id'
+                labels: {
+                  component: 'B',
+                  tag: 'v2',
+                  circleId: 'circle-id'
                 },
-                'name': 'circle-id'
+                name: 'circle-id'
               },
               {
-                'labels': {
-                  'component': 'B',
-                  'tag': 'v0',
-                  'circleId': 'default-circle-id'
+                labels: {
+                  component: 'B',
+                  tag: 'v0',
+                  circleId: 'default-circle-id'
                 },
-                'name': 'default-circle-id'
+                name: 'default-circle-id'
               }
             ]
           }
         }
       ],
-      'moniker': {
-        'app': 'default'
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy Destination Rules B',
-      'refId': '9',
-      'requisiteStageRefIds': [
+      name: 'Deploy Destination Rules B',
+      refId: '9',
+      requisiteStageRefIds: [
         '13'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'text',
-      'stageEnabled': {
-        'expression': '${deploymentResult}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'text',
+      stageEnabled: {
+        expression: '${deploymentResult}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifests': [
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifests: [
         {
-          'apiVersion': 'networking.istio.io/v1alpha3',
-          'kind': 'VirtualService',
-          'metadata': {
-            'name': 'B',
-            'namespace': 'sandbox'
+          apiVersion: 'networking.istio.io/v1alpha3',
+          kind: 'VirtualService',
+          metadata: {
+            name: 'B',
+            namespace: 'sandbox'
           },
-          'spec': {
-            'gateways': [],
-            'hosts': [
+          spec: {
+            gateways: [],
+            hosts: [
               'B'
             ],
-            'http': [
+            http: [
               {
-                'match': [
+                match: [
                   {
-                    'headers': {
-                      'cookie': {
-                        'regex': '.*x-circle-id=circle-id.*'
+                    headers: {
+                      cookie: {
+                        regex: '.*x-circle-id=circle-id.*'
                       }
                     }
                   }
                 ],
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'B',
-                      'subset': 'circle-id'
+                    destination: {
+                      host: 'B',
+                      subset: 'circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       }
@@ -667,29 +687,29 @@ export const completeWithOverrides = {
                 ]
               },
               {
-                'match': [
+                match: [
                   {
-                    'headers': {
+                    headers: {
                       'x-circle-id': {
-                        'exact': 'circle-id'
+                        exact: 'circle-id'
                       }
                     }
                   }
                 ],
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'B',
-                      'subset': 'circle-id'
+                    destination: {
+                      host: 'B',
+                      subset: 'circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       }
@@ -698,20 +718,20 @@ export const completeWithOverrides = {
                 ]
               },
               {
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'B',
-                      'subset': 'default-circle-id'
+                    destination: {
+                      host: 'B',
+                      subset: 'default-circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'default-circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'default-circle-id'
                         }
                       }
@@ -723,133 +743,133 @@ export const completeWithOverrides = {
           }
         }
       ],
-      'moniker': {
-        'app': 'default'
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy Virtual Service B',
-      'refId': '10',
-      'requisiteStageRefIds': [
+      name: 'Deploy Virtual Service B',
+      refId: '10',
+      requisiteStageRefIds: [
         '9'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'text',
-      'stageEnabled': {
-        'expression': '${ #stage(\'Deploy Destination Rules B\').status.toString() == \'SUCCEEDED\'}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'text',
+      stageEnabled: {
+        expression: '${ #stage(\'Deploy Destination Rules B\').status.toString() == \'SUCCEEDED\'}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifests': [
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifests: [
         {
-          'apiVersion': 'networking.istio.io/v1alpha3',
-          'kind': 'DestinationRule',
-          'metadata': {
-            'name': 'C',
-            'namespace': 'sandbox'
+          apiVersion: 'networking.istio.io/v1alpha3',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'C',
+            namespace: 'sandbox'
           },
-          'spec': {
-            'host': 'C',
-            'subsets': [
+          spec: {
+            host: 'C',
+            subsets: [
               {
-                'labels': {
-                  'component': 'C',
-                  'tag': 'v2',
-                  'circleId': 'circle-id'
+                labels: {
+                  component: 'C',
+                  tag: 'v2',
+                  circleId: 'circle-id'
                 },
-                'name': 'circle-id'
+                name: 'circle-id'
               },
               {
-                'labels': {
-                  'component': 'C',
-                  'tag': 'v0',
-                  'circleId': 'default-circle-id'
+                labels: {
+                  component: 'C',
+                  tag: 'v0',
+                  circleId: 'default-circle-id'
                 },
-                'name': 'default-circle-id'
+                name: 'default-circle-id'
               }
             ]
           }
         }
       ],
-      'moniker': {
-        'app': 'default'
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy Destination Rules C',
-      'refId': '11',
-      'requisiteStageRefIds': [
+      name: 'Deploy Destination Rules C',
+      refId: '11',
+      requisiteStageRefIds: [
         '13'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'text',
-      'stageEnabled': {
-        'expression': '${deploymentResult}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'text',
+      stageEnabled: {
+        expression: '${deploymentResult}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'account': 'default',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'manifests': [
+      account: 'default',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      manifests: [
         {
-          'apiVersion': 'networking.istio.io/v1alpha3',
-          'kind': 'VirtualService',
-          'metadata': {
-            'name': 'C',
-            'namespace': 'sandbox'
+          apiVersion: 'networking.istio.io/v1alpha3',
+          kind: 'VirtualService',
+          metadata: {
+            name: 'C',
+            namespace: 'sandbox'
           },
-          'spec': {
-            'gateways': [],
-            'hosts': [
+          spec: {
+            gateways: [],
+            hosts: [
               'C'
             ],
-            'http': [
+            http: [
               {
-                'match': [
+                match: [
                   {
-                    'headers': {
-                      'cookie': {
-                        'regex': '.*x-circle-id=circle-id.*'
+                    headers: {
+                      cookie: {
+                        regex: '.*x-circle-id=circle-id.*'
                       }
                     }
                   }
                 ],
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'C',
-                      'subset': 'circle-id'
+                    destination: {
+                      host: 'C',
+                      subset: 'circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       }
@@ -858,29 +878,29 @@ export const completeWithOverrides = {
                 ]
               },
               {
-                'match': [
+                match: [
                   {
-                    'headers': {
+                    headers: {
                       'x-circle-id': {
-                        'exact': 'circle-id'
+                        exact: 'circle-id'
                       }
                     }
                   }
                 ],
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'C',
-                      'subset': 'circle-id'
+                    destination: {
+                      host: 'C',
+                      subset: 'circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'circle-id'
                         }
                       }
@@ -889,20 +909,20 @@ export const completeWithOverrides = {
                 ]
               },
               {
-                'route': [
+                route: [
                   {
-                    'destination': {
-                      'host': 'C',
-                      'subset': 'default-circle-id'
+                    destination: {
+                      host: 'C',
+                      subset: 'default-circle-id'
                     },
-                    'headers': {
-                      'request': {
-                        'set': {
+                    headers: {
+                      request: {
+                        set: {
                           'x-circle-source': 'default-circle-id'
                         }
                       },
-                      'response': {
-                        'set': {
+                      response: {
+                        set: {
                           'x-circle-source': 'default-circle-id'
                         }
                       }
@@ -914,323 +934,323 @@ export const completeWithOverrides = {
           }
         }
       ],
-      'moniker': {
-        'app': 'default'
+      moniker: {
+        app: 'default'
       },
-      'name': 'Deploy Virtual Service C',
-      'refId': '12',
-      'requisiteStageRefIds': [
+      name: 'Deploy Virtual Service C',
+      refId: '12',
+      requisiteStageRefIds: [
         '11'
       ],
-      'skipExpressionEvaluation': false,
-      'source': 'text',
-      'stageEnabled': {
-        'expression': '${ #stage(\'Deploy Destination Rules C\').status.toString() == \'SUCCEEDED\'}',
-        'type': 'expression'
+      skipExpressionEvaluation: false,
+      source: 'text',
+      stageEnabled: {
+        expression: '${ #stage(\'Deploy Destination Rules C\').status.toString() == \'SUCCEEDED\'}',
+        type: 'expression'
       },
-      'trafficManagement': {
-        'enabled': false,
-        'options': {
-          'enableTraffic': false,
-          'services': []
+      trafficManagement: {
+        enabled: false,
+        options: {
+          enableTraffic: false,
+          services: []
         }
       },
-      'type': 'deployManifest'
+      type: 'deployManifest'
     },
     {
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failOnFailedExpressions': true,
-      'failPipeline': false,
-      'name': 'Evaluate deployments',
-      'refId': '13',
-      'requisiteStageRefIds': [
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failOnFailedExpressions: true,
+      failPipeline: false,
+      name: 'Evaluate deployments',
+      refId: '13',
+      requisiteStageRefIds: [
         '2',
         '4',
         '6'
       ],
-      'type': 'evaluateVariables',
-      'variables': [
+      type: 'evaluateVariables',
+      variables: [
         {
-          'key': 'deploymentResult',
-          'value': '${#stage(\'Deploy A v2\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy B v2\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy C v2\').status.toString() == \'SUCCEEDED\'}'
+          key: 'deploymentResult',
+          value: '${#stage(\'Deploy A v2\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy B v2\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy C v2\').status.toString() == \'SUCCEEDED\'}'
         }
       ]
     },
     {
-      'failOnFailedExpressions': true,
-      'name': 'Evaluate proxy deployments',
-      'refId': '14',
-      'requisiteStageRefIds': [
+      failOnFailedExpressions: true,
+      name: 'Evaluate proxy deployments',
+      refId: '14',
+      requisiteStageRefIds: [
         '8',
         '10',
         '12'
       ],
-      'type': 'evaluateVariables',
-      'variables': [
+      type: 'evaluateVariables',
+      variables: [
         {
-          'key': 'proxyDeploymentsResult',
-          'value': '${#stage(\'Deploy Virtual Service A\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy Virtual Service B\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy Virtual Service C\').status.toString() == \'SUCCEEDED\'}'
+          key: 'proxyDeploymentsResult',
+          value: '${#stage(\'Deploy Virtual Service A\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy Virtual Service B\').status.toString() == \'SUCCEEDED\' && #stage(\'Deploy Virtual Service C\').status.toString() == \'SUCCEEDED\'}'
         }
       ]
     },
     {
-      'account': 'default',
-      'app': 'app-cd-configuration-id',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'kinds': [
+      account: 'default',
+      app: 'app-cd-configuration-id',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      kinds: [
         'deployment'
       ],
-      'labelSelectors': {
-        'selectors': [
+      labelSelectors: {
+        selectors: [
           {
-            'key': 'component',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'component',
+            kind: 'EQUALS',
+            values: [
               'A'
             ]
           },
           {
-            'key': 'tag',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'tag',
+            kind: 'EQUALS',
+            values: [
               'v2'
             ]
           },
           {
-            'key': 'circleId',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'circleId',
+            kind: 'EQUALS',
+            values: [
               'circle-id'
             ]
           }
         ]
       },
-      'location': 'sandbox',
-      'mode': 'label',
-      'name': 'Delete Deployment A v2',
-      'options': {
-        'cascading': true
+      location: 'sandbox',
+      mode: 'label',
+      name: 'Delete Deployment A v2',
+      options: {
+        cascading: true
       },
-      'refId': '15',
-      'requisiteStageRefIds': [
+      refId: '15',
+      requisiteStageRefIds: [
         '13'
       ],
-      'stageEnabled': {
-        'expression': '${!deploymentResult}',
-        'type': 'expression'
+      stageEnabled: {
+        expression: '${!deploymentResult}',
+        type: 'expression'
       },
-      'type': 'deleteManifest'
+      type: 'deleteManifest'
     },
     {
-      'account': 'default',
-      'app': 'app-cd-configuration-id',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'kinds': [
+      account: 'default',
+      app: 'app-cd-configuration-id',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      kinds: [
         'deployment'
       ],
-      'labelSelectors': {
-        'selectors': [
+      labelSelectors: {
+        selectors: [
           {
-            'key': 'component',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'component',
+            kind: 'EQUALS',
+            values: [
               'B'
             ]
           },
           {
-            'key': 'tag',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'tag',
+            kind: 'EQUALS',
+            values: [
               'v2'
             ]
           },
           {
-            'key': 'circleId',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'circleId',
+            kind: 'EQUALS',
+            values: [
               'circle-id'
             ]
           }
         ]
       },
-      'location': 'sandbox',
-      'mode': 'label',
-      'name': 'Delete Deployment B v2',
-      'options': {
-        'cascading': true
+      location: 'sandbox',
+      mode: 'label',
+      name: 'Delete Deployment B v2',
+      options: {
+        cascading: true
       },
-      'refId': '16',
-      'requisiteStageRefIds': [
+      refId: '16',
+      requisiteStageRefIds: [
         '13'
       ],
-      'stageEnabled': {
-        'expression': '${!deploymentResult}',
-        'type': 'expression'
+      stageEnabled: {
+        expression: '${!deploymentResult}',
+        type: 'expression'
       },
-      'type': 'deleteManifest'
+      type: 'deleteManifest'
     },
     {
-      'account': 'default',
-      'app': 'app-cd-configuration-id',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'kinds': [
+      account: 'default',
+      app: 'app-cd-configuration-id',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      kinds: [
         'deployment'
       ],
-      'labelSelectors': {
-        'selectors': [
+      labelSelectors: {
+        selectors: [
           {
-            'key': 'component',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'component',
+            kind: 'EQUALS',
+            values: [
               'A'
             ]
           },
           {
-            'key': 'tag',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'tag',
+            kind: 'EQUALS',
+            values: [
               'v1'
             ]
           },
           {
-            'key': 'circleId',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'circleId',
+            kind: 'EQUALS',
+            values: [
               'circle-id'
             ]
           }
         ]
       },
-      'location': 'sandbox',
-      'mode': 'label',
-      'name': 'Delete Unused Deployment A v1',
-      'nameStage': 'Delete Deployments',
-      'options': {
-        'cascading': true
+      location: 'sandbox',
+      mode: 'label',
+      name: 'Delete Unused Deployment A v1',
+      nameStage: 'Delete Deployments',
+      options: {
+        cascading: true
       },
-      'refId': '17',
-      'requisiteStageRefIds': [
+      refId: '17',
+      requisiteStageRefIds: [
         '14'
       ],
-      'stageEnabled': {
-        'expression': '${proxyDeploymentsResult}',
-        'type': 'expression'
+      stageEnabled: {
+        expression: '${proxyDeploymentsResult}',
+        type: 'expression'
       },
-      'type': 'deleteManifest'
+      type: 'deleteManifest'
     },
     {
-      'account': 'default',
-      'app': 'app-cd-configuration-id',
-      'cloudProvider': 'kubernetes',
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'failPipeline': false,
-      'kinds': [
+      account: 'default',
+      app: 'app-cd-configuration-id',
+      cloudProvider: 'kubernetes',
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      failPipeline: false,
+      kinds: [
         'deployment'
       ],
-      'labelSelectors': {
-        'selectors': [
+      labelSelectors: {
+        selectors: [
           {
-            'key': 'component',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'component',
+            kind: 'EQUALS',
+            values: [
               'B'
             ]
           },
           {
-            'key': 'tag',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'tag',
+            kind: 'EQUALS',
+            values: [
               'v1'
             ]
           },
           {
-            'key': 'circleId',
-            'kind': 'EQUALS',
-            'values': [
+            key: 'circleId',
+            kind: 'EQUALS',
+            values: [
               'circle-id'
             ]
           }
         ]
       },
-      'location': 'sandbox',
-      'mode': 'label',
-      'name': 'Delete Unused Deployment B v1',
-      'nameStage': 'Delete Deployments',
-      'options': {
-        'cascading': true
+      location: 'sandbox',
+      mode: 'label',
+      name: 'Delete Unused Deployment B v1',
+      nameStage: 'Delete Deployments',
+      options: {
+        cascading: true
       },
-      'refId': '18',
-      'requisiteStageRefIds': [
+      refId: '18',
+      requisiteStageRefIds: [
         '14'
       ],
-      'stageEnabled': {
-        'expression': '${proxyDeploymentsResult}',
-        'type': 'expression'
+      stageEnabled: {
+        expression: '${proxyDeploymentsResult}',
+        type: 'expression'
       },
-      'type': 'deleteManifest'
+      type: 'deleteManifest'
     },
     {
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'customHeaders': {
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      customHeaders: {
         'x-circle-id': 'Default'
       },
-      'failPipeline': false,
-      'method': 'POST',
-      'name': 'Trigger Failure Webhook',
-      'payload': {
-        'status': 'FAILED',
-        'type': 'DEPLOYMENT'
+      failPipeline: false,
+      method: 'POST',
+      name: 'Trigger Failure Webhook',
+      payload: {
+        status: DeploymentStatusEnum.FAILED,
+        type: ExecutionTypeEnum.DEPLOYMENT
       },
-      'refId': '19',
-      'requisiteStageRefIds': [
+      refId: '19',
+      requisiteStageRefIds: [
         '13',
         '14'
       ],
-      'stageEnabled': {
-        'expression': '${ !deploymentResult || !proxyDeploymentsResult }',
-        'type': 'expression'
+      stageEnabled: {
+        expression: '${ !deploymentResult || !proxyDeploymentsResult }',
+        type: 'expression'
       },
-      'statusUrlResolution': 'getMethod',
-      'type': 'webhook',
-      'url': 'http://localhost:8883/butler/v2/executions/execution-id/notify'
+      statusUrlResolution: 'getMethod',
+      type: 'webhook',
+      url: 'http://localhost:8883/butler/v2/executions/execution-id/notify'
     },
     {
-      'completeOtherBranchesThenFail': false,
-      'continuePipeline': true,
-      'customHeaders': {
+      completeOtherBranchesThenFail: false,
+      continuePipeline: true,
+      customHeaders: {
         'x-circle-id': 'Default'
       },
-      'failPipeline': false,
-      'method': 'POST',
-      'name': 'Trigger Success Webhook',
-      'payload': {
-        'status': 'SUCCEEDED',
-        'type': 'DEPLOYMENT'
+      failPipeline: false,
+      method: 'POST',
+      name: 'Trigger Success Webhook',
+      payload: {
+        status: DeploymentStatusEnum.SUCCEEDED,
+        type: ExecutionTypeEnum.DEPLOYMENT
       },
-      'refId': '20',
-      'requisiteStageRefIds': [
+      refId: '20',
+      requisiteStageRefIds: [
         '13',
         '14'
       ],
-      'stageEnabled': {
-        'expression': '${ deploymentResult && proxyDeploymentsResult }',
-        'type': 'expression'
+      stageEnabled: {
+        expression: '${ deploymentResult && proxyDeploymentsResult }',
+        type: 'expression'
       },
-      'statusUrlResolution': 'getMethod',
-      'type': 'webhook',
-      'url': 'http://localhost:8883/butler/v2/executions/execution-id/notify'
+      statusUrlResolution: 'getMethod',
+      type: 'webhook',
+      url: 'http://localhost:8883/butler/v2/executions/execution-id/notify'
     }
   ]
 }

--- a/butler/src/tests/v2/unit/spinnaker/pipeline-builder-deployment-override.spec.ts
+++ b/butler/src/tests/v2/unit/spinnaker/pipeline-builder-deployment-override.spec.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'jest'
+import { CdTypeEnum } from '../../../../app/v1/api/configurations/enums'
+import { Component, Deployment } from '../../../../app/v2/api/deployments/interfaces'
+import { SpinnakerPipelineBuilder } from '../../../../app/v2/core/integrations/spinnaker/pipeline-builder'
+import { completeWithOverrides } from './fixtures/deployment/deployment-complete-with-overrides'
+
+describe('V2 Spinnaker Deployment Pipeline Builder - override deployments', () => {
+
+  it('should create the correct complete pipeline object with 3 new components overriding all components on active circle', async() => {
+
+    const deploymentWith3Components: Deployment = {
+      id: 'deployment-id',
+      authorId: 'user-1',
+      callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=1',
+      cdConfiguration: {
+        id: 'cd-configuration-id',
+        type: CdTypeEnum.SPINNAKER,
+        configurationData: {
+          gitAccount: 'github-artifact',
+          account: 'default',
+          namespace: 'sandbox',
+          url: 'spinnaker-url'
+        },
+        name: 'spinnakerconfiguration',
+        authorId: 'user-2',
+        workspaceId: 'workspace-id',
+        createdAt: new Date(),
+        deployments: null
+      },
+      defaultCircle: false,
+      circleId: 'circle-id',
+      createdAt: new Date(),
+      components: [
+        {
+          id: 'component-id-1',
+          helmUrl: 'http://localhost:2222/helm',
+          imageTag: 'v2',
+          imageUrl: 'https://repository.com/A:v2',
+          name: 'A',
+          running: false,
+          gatewayName: null,
+          hostValue: null
+        },
+        {
+          id: 'component-id-2',
+          helmUrl: 'http://localhost:2222/helm',
+          imageTag: 'v2',
+          imageUrl: 'https://repository.com/B:v2',
+          name: 'B',
+          running: false,
+          gatewayName: null,
+          hostValue: null
+        },
+        {
+          id: 'component-id-3',
+          helmUrl: 'http://localhost:2222/helm',
+          imageTag: 'v2',
+          imageUrl: 'https://repository.com/C:v2',
+          name: 'C',
+          running: false,
+          gatewayName: null,
+          hostValue: null
+        }
+      ]
+    }
+
+    const activeComponents: Component[] = [
+      {
+        id: 'component-id-4',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v1',
+        imageUrl: 'https://repository.com/A:v1',
+        name: 'A',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id4',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=4',
+          circleId: 'circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.SPINNAKER,
+            configurationData: {
+              gitAccount: 'github-artifact',
+              account: 'default',
+              namespace: 'sandbox',
+              url: 'spinnaker-url'
+            },
+            name: 'spinnakerconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: false
+        }
+      },
+      {
+        id: 'component-id-5',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v1',
+        imageUrl: 'https://repository.com/B:v1',
+        name: 'B',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id5',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=5',
+          circleId: 'circle-id',
+          defaultCircle: false,
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.SPINNAKER,
+            configurationData: {
+              gitAccount: 'github-artifact',
+              account: 'default',
+              namespace: 'sandbox',
+              url: 'spinnaker-url'
+            },
+            name: 'spinnakerconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+        }
+      },
+      {
+        id: 'component-id-66',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v2',
+        imageUrl: 'https://repository.com/C:v2',
+        name: 'C',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'component-id-66',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=5',
+          circleId: 'circle-id',
+          defaultCircle: false,
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.SPINNAKER,
+            configurationData: {
+              gitAccount: 'github-artifact',
+              account: 'default',
+              namespace: 'sandbox',
+              url: 'spinnaker-url'
+            },
+            name: 'spinnakerconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+        }
+      },
+      {
+        id: 'component-id-6',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v0',
+        imageUrl: 'https://repository.com/A:v0',
+        name: 'A',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id6',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=6',
+          circleId: 'default-circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.SPINNAKER,
+            configurationData: {
+              gitAccount: 'github-artifact',
+              account: 'default',
+              namespace: 'sandbox',
+              url: 'spinnaker-url'
+            },
+            name: 'spinnakerconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: true
+        }
+      },
+      {
+        id: 'component-id-7',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v0',
+        imageUrl: 'https://repository.com/B:v0',
+        name: 'B',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id7',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=7',
+          circleId: 'default-circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.SPINNAKER,
+            configurationData: {
+              gitAccount: 'github-artifact',
+              account: 'default',
+              namespace: 'sandbox',
+              url: 'spinnaker-url'
+            },
+            name: 'spinnakerconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: true
+        }
+      },
+      {
+        id: 'component-id-8',
+        helmUrl: 'http://localhost:2222/helm',
+        imageTag: 'v0',
+        imageUrl: 'https://repository.com/C:v0',
+        name: 'C',
+        running: true,
+        gatewayName: null,
+        hostValue: null,
+        deployment: {
+          id: 'deployment-id8',
+          authorId: 'user-1',
+          callbackUrl: 'http://localhost:1234/notifications/deployment?deploymentId=8',
+          circleId: 'default-circle-id',
+          createdAt: new Date(),
+          cdConfiguration: {
+            id: 'cd-configuration-id',
+            type: CdTypeEnum.SPINNAKER,
+            configurationData: {
+              gitAccount: 'github-artifact',
+              account: 'default',
+              namespace: 'sandbox',
+              url: 'spinnaker-url'
+            },
+            name: 'spinnakerconfiguration',
+            authorId: 'user-2',
+            workspaceId: 'workspace-id',
+            createdAt: new Date(),
+            deployments: null
+          },
+          defaultCircle: true
+        }
+      }
+    ]
+
+    expect(
+      new SpinnakerPipelineBuilder().buildSpinnakerDeploymentPipeline(deploymentWith3Components, activeComponents, { executionId: 'execution-id', incomingCircleId: 'Default' })
+    ).toEqual(completeWithOverrides)
+  })
+})

--- a/butler/src/tests/v2/unit/utils/replaced-components.spec.ts
+++ b/butler/src/tests/v2/unit/utils/replaced-components.spec.ts
@@ -1,0 +1,189 @@
+// circulo 1:
+// Componentes: A:v1, B:v1, C:v1
+
+// Componentes: A:v1, B:v2
+// B:v1, C:v1
+
+import { flatMap, uniq, uniqBy } from 'lodash'
+import { CdConfigurationEntity } from '../../../../app/v1/api/configurations/entity'
+import { CdTypeEnum } from '../../../../app/v1/api/configurations/enums'
+import { GitProvidersEnum } from '../../../../app/v1/core/integrations/configuration/interfaces'
+import { ClusterProviderEnum } from '../../../../app/v1/core/integrations/octopipe/interfaces/octopipe-payload.interface'
+import { ComponentEntityV2 } from '../../../../app/v2/api/deployments/entity/component.entity'
+import { DeploymentEntityV2 } from '../../../../app/v2/api/deployments/entity/deployment.entity'
+import { Component } from '../../../../app/v2/api/deployments/interfaces/component.interface'
+import { Deployment, DeploymentComponent } from '../../../../app/v2/api/deployments/interfaces/deployment.interface'
+import { OctopipeDeployment } from '../../../../app/v2/core/integrations/octopipe/interfaces/octopipe-deployment.interface'
+
+it('must replace new components version', async() => {
+  const cdConfiguration = new CdConfigurationEntity(
+    CdTypeEnum.OCTOPIPE,
+    {
+      provider: ClusterProviderEnum.DEFAULT,
+      gitProvider: GitProvidersEnum.GITHUB,
+      gitToken: '123',
+      namespace: 'default'
+    },
+    'some-config',
+    'author-id',
+    'workspace-id'
+  )
+  let activeComponents = [
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'A:v1',
+      'component-a',
+      'component-a-id',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'B:v1',
+      'component-b',
+      'component-b-id',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'C:v1',
+      'component-c',
+      'component-c-id',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'D:v1',
+      'component-d',
+      'component-d-id',
+      null,
+      null
+    )
+  ]
+  const components = [
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'A:v1',
+      'component-a',
+      'component-a-id',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v2',
+      'B:v2',
+      'component-b',
+      'component-b-id',
+      null,
+      null
+    )
+  ]
+  const deployment = new DeploymentEntityV2(
+    'deployment-id',
+    'author-id',
+    'circle-id',
+    cdConfiguration,
+    'www.callback.com',
+    components,
+    false
+  )
+
+  activeComponents = activeComponents.map(c => {
+    c.deployment = deployment
+    return c
+  })
+
+  const replacedVersions = replaceVersions(deployment, activeComponents)
+  const expectedComponents = [
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'B:v1',
+      'component-b',
+      'component-b-id',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'C:v1',
+      'component-c',
+      'component-c-id',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v1',
+      'D:v1',
+      'component-d',
+      'component-d-id',
+      null,
+      null
+    )
+  ]
+  expect(replacedVersions.map((c) => {
+    return {
+      name: c.name,
+      imageUrl: c.imageUrl
+    }
+  })).toEqual(expectedComponents.map(c => {
+    return {
+      name: c.name,
+      imageUrl: c.imageUrl
+    }
+  }))
+})
+
+
+
+
+const replaceVersions = (deployment: Deployment, activeComponents: Component[]): DeploymentComponent[] => {
+  const circleId = deployment.circleId
+  return activeComponents.filter(c => {
+    return non(deployment.components, c, circleId) || updated(deployment.components, c, circleId)
+    return !deployment.components?.some(dc => nonExistendConditions(dc, c, circleId)) || deployment.components?.some(dc => oldVersionCondition(dc, c, circleId))
+  })
+  const removedComponents = activeComponents.filter(c => !deployment.components?.some(dc => nonExistendConditions(dc, c, circleId)))
+  const updatedComponents = activeComponents.filter(c => deployment.components?.some(dc => oldVersionCondition(dc, c, circleId)))
+  return updatedComponents.concat(removedComponents)
+}
+
+const non = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
+  return !deploymentComponents?.some(dc => nonExistendConditions(dc, activeComponent, circleId))
+}
+
+const updated = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
+  return deploymentComponents?.some(dc => oldVersionCondition(dc, activeComponent, circleId))
+}
+
+const nonExistendConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
+  return isSameName(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
+}
+
+const oldVersionCondition = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
+  return isSameNameAndDifferenteVersion(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
+}
+
+const isSameNameAndDifferenteVersion = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
+  return isSameName(deploymentComponent, activeComponent) && deploymentComponent.imageUrl !== activeComponent.imageUrl
+}
+
+const isSameName = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
+  return deploymentComponent.name === activeComponent.name
+}
+
+const isSameCircle = (circleId: string, deployment: Deployment): boolean => {
+  return circleId === deployment.circleId
+}
+
+

--- a/butler/src/tests/v2/unit/utils/replaced-components.spec.ts
+++ b/butler/src/tests/v2/unit/utils/replaced-components.spec.ts
@@ -6,7 +6,7 @@ import { ComponentEntityV2 } from '../../../../app/v2/api/deployments/entity/com
 import { DeploymentEntityV2 } from '../../../../app/v2/api/deployments/entity/deployment.entity'
 import { componentsToBeRemoved } from '../../../../app/v2/core/integrations/utils/deployment.utils'
 
-it('must replace new components version', async() => {
+it('new deployment with active components on default circle', async() => {
   const cdConfiguration = new CdConfigurationEntity(
     CdTypeEnum.OCTOPIPE,
     {
@@ -19,118 +19,143 @@ it('must replace new components version', async() => {
     'author-id',
     'workspace-id'
   )
-  let activeComponents = [
+
+  let activeOnCircle = [
     new ComponentEntityV2(
       'helm.url',
       'v1',
-      'A:v1',
+      'https://repository.com/A:v1',
       'component-a',
-      'component-a-id',
+      'component-a-id-1',
       null,
       null
     ),
     new ComponentEntityV2(
       'helm.url',
       'v1',
-      'B:v1',
+      'https://repository.com/B:v1',
       'component-b',
-      'component-b-id',
-      null,
-      null
-    ),
-    new ComponentEntityV2(
-      'helm.url',
-      'v1',
-      'C:v1',
-      'component-c',
-      'component-c-id',
-      null,
-      null
-    ),
-    new ComponentEntityV2(
-      'helm.url',
-      'v1',
-      'D:v1',
-      'component-d',
-      'component-d-id',
-      null,
-      null
-    )
-  ]
-  const components = [
-    new ComponentEntityV2(
-      'helm.url',
-      'v1',
-      'A:v1',
-      'component-a',
-      'component-a-id',
+      'component-b-id-2',
       null,
       null
     ),
     new ComponentEntityV2(
       'helm.url',
       'v2',
-      'B:v2',
-      'component-b',
-      'component-b-id',
+      'https://repository.com/C:v2',
+      'component-c',
+      'component-c-id-33',
       null,
       null
     )
   ]
-  const deployment = new DeploymentEntityV2(
+
+  let activeOnDefault = [
+    new ComponentEntityV2(
+      'helm.url',
+      'v0',
+      'https://repository.com/A:v0',
+      'component-a',
+      'component-a-id-3',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v0',
+      'https://repository.com/B:v0',
+      'component-b',
+      'component-b-id-4',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v0',
+      'https://repository.com/C:v0',
+      'component-c',
+      'component-c-id-5',
+      null,
+      null
+    )
+  ]
+
+  const activeComponents = activeOnDefault.concat(activeOnCircle)
+
+  const circleDeployments = new DeploymentEntityV2(
     'deployment-id',
     'author-id',
     'circle-id',
     cdConfiguration,
     'www.callback.com',
-    components,
+    activeOnCircle,
     false
   )
+  const defaultDeployment = new DeploymentEntityV2(
+    'deployment-id-2',
+    'author-id',
+    'default-circle-id',
+    cdConfiguration,
+    'www.callback.com',
+    activeOnDefault,
+    true
+  )
 
-  activeComponents = activeComponents.map(c => {
-    c.deployment = deployment
+  activeOnDefault = activeOnDefault.map(c => {
+    c.deployment = defaultDeployment
     return c
   })
 
-  const removedVersions = componentsToBeRemoved(deployment, activeComponents)
-  const expectedComponents = [
+  activeOnCircle = activeOnCircle.map(c => {
+    c.deployment = circleDeployments
+    return c
+  })
+
+  let newComponents = [
     new ComponentEntityV2(
       'helm.url',
-      'v1',
-      'B:v1',
+      'v2',
+      'https://repository.com/A:v2',
+      'component-a',
+      'component-a-id-11',
+      null,
+      null
+    ),
+    new ComponentEntityV2(
+      'helm.url',
+      'v2',
+      'https://repository.com/B:v2',
       'component-b',
-      'component-b-id',
+      'component-b-id-22',
       null,
       null
     ),
     new ComponentEntityV2(
       'helm.url',
-      'v1',
-      'C:v1',
+      'v2',
+      'https://repository.com/C:v2',
       'component-c',
-      'component-c-id',
-      null,
-      null
-    ),
-    new ComponentEntityV2(
-      'helm.url',
-      'v1',
-      'D:v1',
-      'component-d',
-      'component-d-id',
+      'component-c-id-33',
       null,
       null
     )
   ]
-  expect(removedVersions.map((c) => {
-    return {
-      name: c.name,
-      imageUrl: c.imageUrl
-    }
-  })).toEqual(expectedComponents.map(c => {
-    return {
-      name: c.name,
-      imageUrl: c.imageUrl
-    }
-  }))
+
+  const newDeployment = new DeploymentEntityV2(
+    'new-deployment-id',
+    'author-id',
+    'circle-id',
+    cdConfiguration,
+    'www.callback.com',
+    newComponents,
+    false
+  )
+
+  newComponents = newComponents.map(c => {
+    c.deployment = newDeployment
+    return c
+  })
+
+  const removedVersions = componentsToBeRemoved(newDeployment, activeComponents)
+  expect(removedVersions.map(c => c.imageUrl)).toEqual(['https://repository.com/A:v1', 'https://repository.com/B:v1'])
 })

--- a/butler/src/tests/v2/unit/utils/replaced-components.spec.ts
+++ b/butler/src/tests/v2/unit/utils/replaced-components.spec.ts
@@ -1,19 +1,10 @@
-// circulo 1:
-// Componentes: A:v1, B:v1, C:v1
-
-// Componentes: A:v1, B:v2
-// B:v1, C:v1
-
-import { flatMap, uniq, uniqBy } from 'lodash'
 import { CdConfigurationEntity } from '../../../../app/v1/api/configurations/entity'
 import { CdTypeEnum } from '../../../../app/v1/api/configurations/enums'
 import { GitProvidersEnum } from '../../../../app/v1/core/integrations/configuration/interfaces'
 import { ClusterProviderEnum } from '../../../../app/v1/core/integrations/octopipe/interfaces/octopipe-payload.interface'
 import { ComponentEntityV2 } from '../../../../app/v2/api/deployments/entity/component.entity'
 import { DeploymentEntityV2 } from '../../../../app/v2/api/deployments/entity/deployment.entity'
-import { Component } from '../../../../app/v2/api/deployments/interfaces/component.interface'
-import { Deployment, DeploymentComponent } from '../../../../app/v2/api/deployments/interfaces/deployment.interface'
-import { OctopipeDeployment } from '../../../../app/v2/core/integrations/octopipe/interfaces/octopipe-deployment.interface'
+import { componentsToBeRemoved } from '../../../../app/v2/core/integrations/utils/deployment.utils'
 
 it('must replace new components version', async() => {
   const cdConfiguration = new CdConfigurationEntity(
@@ -101,7 +92,7 @@ it('must replace new components version', async() => {
     return c
   })
 
-  const replacedVersions = replaceVersions(deployment, activeComponents)
+  const removedVersions = componentsToBeRemoved(deployment, activeComponents)
   const expectedComponents = [
     new ComponentEntityV2(
       'helm.url',
@@ -131,7 +122,7 @@ it('must replace new components version', async() => {
       null
     )
   ]
-  expect(replacedVersions.map((c) => {
+  expect(removedVersions.map((c) => {
     return {
       name: c.name,
       imageUrl: c.imageUrl
@@ -143,47 +134,3 @@ it('must replace new components version', async() => {
     }
   }))
 })
-
-
-
-
-const replaceVersions = (deployment: Deployment, activeComponents: Component[]): DeploymentComponent[] => {
-  const circleId = deployment.circleId
-  return activeComponents.filter(c => {
-    return non(deployment.components, c, circleId) || updated(deployment.components, c, circleId)
-    return !deployment.components?.some(dc => nonExistendConditions(dc, c, circleId)) || deployment.components?.some(dc => oldVersionCondition(dc, c, circleId))
-  })
-  const removedComponents = activeComponents.filter(c => !deployment.components?.some(dc => nonExistendConditions(dc, c, circleId)))
-  const updatedComponents = activeComponents.filter(c => deployment.components?.some(dc => oldVersionCondition(dc, c, circleId)))
-  return updatedComponents.concat(removedComponents)
-}
-
-const non = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
-  return !deploymentComponents?.some(dc => nonExistendConditions(dc, activeComponent, circleId))
-}
-
-const updated = (deploymentComponents: DeploymentComponent[] | undefined, activeComponent: Component, circleId: string) => {
-  return deploymentComponents?.some(dc => oldVersionCondition(dc, activeComponent, circleId))
-}
-
-const nonExistendConditions = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
-  return isSameName(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
-}
-
-const oldVersionCondition = (deploymentComponent: DeploymentComponent, activeComponent: Component, circleId: string): boolean => {
-  return isSameNameAndDifferenteVersion(deploymentComponent, activeComponent) && isSameCircle(circleId, activeComponent.deployment)
-}
-
-const isSameNameAndDifferenteVersion = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
-  return isSameName(deploymentComponent, activeComponent) && deploymentComponent.imageUrl !== activeComponent.imageUrl
-}
-
-const isSameName = (deploymentComponent: DeploymentComponent, activeComponent: Component): boolean => {
-  return deploymentComponent.name === activeComponent.name
-}
-
-const isSameCircle = (circleId: string, deployment: Deployment): boolean => {
-  return circleId === deployment.circleId
-}
-
-

--- a/circle-matcher/README.md
+++ b/circle-matcher/README.md
@@ -43,6 +43,18 @@ The response could be:
 ```
 Then, simply use the circle identification information for any service call in your cluster. To do this, use the HTTP header **X-Circle-Id** with the value of **circles.id**.
 
+## Running locally
+
+First up the Redis container:
+```
+docker-compose -f docker-compose.xml up
+```
+
+Then run the application (if you want to run with another Redis flavors, use the appropriate profile):
+```
+mvn spring-boot:run -Dspring-boot.run.profiles=local
+```
+
 ## Documentation
 
 Please check the [Charles Documentation].

--- a/circle-matcher/docker-compose.yml
+++ b/circle-matcher/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   redis:
-    image: 'bitnami/redis:3.2.9-r3'
+    image: 'docker.io/bitnami/redis:3.2.9-r3'
     ports:
       - '6379:6379'
     environment:

--- a/circle-matcher/docker-compose.yml
+++ b/circle-matcher/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   redis:
-    image: 'docker.io/bitnami/redis:3.2.9-r3'
+    image: 'bitnami/redis:3.2.9-r3'
     ports:
       - '6379:6379'
     environment:

--- a/compass/README.md
+++ b/compass/README.md
@@ -1,0 +1,61 @@
+# CharlesCD Compass
+
+Compass is CharlesCD's application responsible for providing metrics through the connection with several data sources, in addition the application allows you to create actions based on the metrics consumed. The Compass also use a plugin architecture, which means that you can develop your own plugins for different data sources.
+
+## How Compass Works
+Through the Compass APIs, you can explore it to:
+- Integrate with metric providers to monitor the health of your applications and explore your circle's evolution.
+- Set thresholds based on your application metrics.
+- Create automated actions based on metrics and thresholds provided by your application.
+- Use different types of data sources thanks to plugin architecture
+
+## How to Use
+
+### Requirements
+ - [Go 1.14]
+ - [Docker]
+ - [Docker Compose]
+ - [GNU Make]
+
+Once all the prerequisites were installed, if you want to run your application locally you will need a metric provider datasource running on the port 9090.
+
+### Building the plugins
+Compass already comes with two datasources plugins by default:
+- [Prometheus]
+- [Google Analytics]
+
+To build the plugin you only need to run the `build-plugins.sh` in compass root folder.
+
+### On terminal
+
+Inside the root folder, run the following command:
+
+```
+docker-compose up
+make start
+```
+
+### Using your IDE
+Once you run the command `docker-compose up` on your terminal, set the `cmd/main.go` as your main file and start the application.
+
+After both approaches, the application will be available on port 8080. Additionally, one container will be running: a PostgreSQL database.
+ 
+Compass provides a up to date [Postman Collection].
+
+## Documentation
+
+Please check our [Documentation].
+
+## Contributing
+
+Please check our [Contributing Guide].
+
+[Go 1.14]: https://golang.org/dl/
+[Prometheus]: https://prometheus.io/
+[Google Analytics]: https://analytics.google.com/
+[GNU Make]: https://www.gnu.org/software/make/
+[Docker]: https://docs.docker.com/get-docker/
+[Docker Compose]: https://docs.docker.com/compose/install/
+[Postman Collection]: resources/postman-collection.mod
+[Contributing Guide]: https://github.com/ZupIT/charlescd/blob/master/CONTRIBUTING.md
+[Documentation]: https://docs.charlescd.io/

--- a/compass/README.md
+++ b/compass/README.md
@@ -1,13 +1,14 @@
 # CharlesCD Compass
 
-Compass is CharlesCD's application responsible for providing metrics through the connection with several data sources, in addition the application allows you to create actions based on the metrics consumed. The Compass also use a plugin architecture, which means that you can develop your own plugins for different data sources.
+Compass is CharlesCD's application responsible for providing metrics through the connection with several data sources, in addition the application allows you to create actions based on the metrics consumed. The Compass also use a plugin architecture, which means that you can develop your own plugins for different data sources also create metrics-based actions plugins.
 
 ## How Compass Works
 Through the Compass APIs, you can explore it to:
 - Integrate with metric providers to monitor the health of your applications and explore your circle's evolution.
 - Set thresholds based on your application metrics.
 - Create automated actions based on metrics and thresholds provided by your application.
-- Use different types of data sources thanks to plugin architecture
+- Use different types of data sources thanks to plugin architecture.
+- Develop your own actions plugins.
 
 ## How to Use
 
@@ -20,9 +21,12 @@ Through the Compass APIs, you can explore it to:
 Once all the prerequisites were installed, if you want to run your application locally you will need a metric provider datasource running on the port 9090.
 
 ### Building the plugins
-Compass already comes with two datasources plugins by default:
+Compass already comes with two data sources plugins and one action plugin by default:
+#### Data sources
 - [Prometheus]
 - [Google Analytics]
+#### Actions
+- [Circle Deployment]
 
 To build the plugin you only need to run the `build-plugins.sh` in compass root folder.
 
@@ -53,6 +57,7 @@ Please check our [Contributing Guide].
 [Go 1.14]: https://golang.org/dl/
 [Prometheus]: https://prometheus.io/
 [Google Analytics]: https://analytics.google.com/
+[Circle Deployment]: plugins/action/circledeployment/circledeployment.go
 [GNU Make]: https://www.gnu.org/software/make/
 [Docker]: https://docs.docker.com/get-docker/
 [Docker Compose]: https://docs.docker.com/compose/install/

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/CreateDeploymentInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/CreateDeploymentInteractorImpl.kt
@@ -47,7 +47,6 @@ open class CreateDeploymentInteractorImpl @Inject constructor(
 
         if (build.canBeDeployed()) {
             val deployment = createDeployment(request, workspaceId)
-            undeployActiveDeploymentFromCircleIfExists(deployment, workspaceId)
             deploymentService.save(deployment)
             deployService.deploy(deployment, build, deployment.circle.isDefaultCircle(), workspace.cdConfigurationId!!)
             return DeploymentResponse.from(deployment, build)
@@ -68,19 +67,5 @@ open class CreateDeploymentInteractorImpl @Inject constructor(
         val circle = circleService.find(request.circleId)
         return request.toDeployment(workspaceId, user, circle)
     }
-
-    private fun undeployActiveDeploymentFromCircleIfExists(
-        deployment: Deployment,
-        workspaceId: String
-    ) {
-        findActiveDeployment(deployment.circle.id, workspaceId)
-            ?.also { deployService.undeploy(it.id, it.author.id) }
-            ?.let { deploymentService.updateStatus(it.id, DeploymentStatusEnum.UNDEPLOYING) }
-    }
-
-    private fun findActiveDeployment(circleId: String, workspaceId: String): Deployment? {
-        return deploymentService.findByCircleIdAndWorkspaceId(circleId, workspaceId).filter { deployment ->
-            deployment.isActive()
-        }.maxBy { it.createdAt }
-    }
+    
 }

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/CreateDeploymentInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/CreateDeploymentInteractorImplTest.groovy
@@ -179,10 +179,7 @@ class CreateDeploymentInteractorImplTest extends Specification {
         1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
         1 * userRepository.findById(author.id) >> Optional.of(author)
         1 * circleRepository.findById(circleId) >> Optional.of(build.deployments[0].circle)
-        1 * deploymentRepository.findByCircleIdAndWorkspaceId(build.deployments[0].circle.id, workspaceId) >> [notDeployedDeployment, activeDeployment]
-        1 * deployService.undeploy(activeDeployment.id, activeDeployment.author.id)
         1 * deploymentRepository.save(_) >> _
-        1 * deploymentRepository.updateStatus(activeDeployment.id, DeploymentStatusEnum.UNDEPLOYING) >> _
         1 * deployService.deploy(_, _, false, _) >> { arguments ->
             def deploymentArgument = arguments[0]
             def buildArgument = arguments[1]
@@ -242,8 +239,6 @@ class CreateDeploymentInteractorImplTest extends Specification {
         1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
         1 * userRepository.findById(author.id) >> Optional.of(author)
         1 * circleRepository.findById(circle.id) >> Optional.of(circle)
-        0 * deployService.undeploy(_, _)
-        1 * deploymentRepository.findByCircleIdAndWorkspaceId(circle.id, workspaceId) >> [notDeployedDeployment, activeDeployment]
         1 * deploymentRepository.save(_) >> _
         1 * deployService.deploy(_, _, true, _) >> { arguments ->
             def deploymentArgument = arguments[0]
@@ -301,8 +296,6 @@ class CreateDeploymentInteractorImplTest extends Specification {
         1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
         1 * userRepository.findById(author.id) >> Optional.of(author)
         1 * circleRepository.findById(circle.id) >> Optional.of(circle)
-        0 * deployService.undeploy(_, _)
-        1 * deploymentRepository.findByCircleIdAndWorkspaceId(build.deployments[0].circle.id, workspaceId) >> [notDeployedDeployment]
         1 * deploymentRepository.save(_) >> _
         1 * deployService.deploy(_, _, true, _) >> { arguments ->
             def deploymentArgument = arguments[0]
@@ -363,8 +356,6 @@ class CreateDeploymentInteractorImplTest extends Specification {
         1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
         1 * userRepository.findById(author.id) >> Optional.of(author)
         1 * circleRepository.findById(circleId) >> Optional.of(build.deployments[0].circle)
-        0 * deployService.undeploy(_, _)
-        1 * deploymentRepository.findByCircleIdAndWorkspaceId(build.deployments[0].circle.id, workspaceId) >> [notDeployedDeployment]
         1 * deploymentRepository.save(_) >> _
         1 * deployService.deploy(_, _, false, _) >> { arguments ->
             def deploymentArgument = arguments[0]

--- a/ui/src/core/components/Badge/__tests__/Badge.spec.tsx
+++ b/ui/src/core/components/Badge/__tests__/Badge.spec.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { render, screen } from 'unit-test/testUtils';
-import Badge from '../';
+import Badge from '..';
 
 test('render Badge', () => {
   render(
@@ -24,4 +24,5 @@ test('render Badge', () => {
   );
 
   expect(screen.getByText('content')).toBeInTheDocument();
+  expect(screen.getByTestId('badge-content')).toBeInTheDocument();
 });

--- a/ui/src/core/components/Badge/index.tsx
+++ b/ui/src/core/components/Badge/index.tsx
@@ -24,7 +24,7 @@ export interface Props {
 
 const Badge = ({ label }: Props) => (
   <Styled.Badge>
-    <Text.h6 color="light" align="center">
+    <Text.h6 color="light" align="center" data-testid={`badge-${label}`}>
       {label}
     </Text.h6>
   </Styled.Badge>

--- a/ui/src/core/components/Card/Release/index.tsx
+++ b/ui/src/core/components/Card/Release/index.tsx
@@ -64,7 +64,9 @@ const CardRelease = forwardRef(
 
     const renderBody = () => (
       <Styled.CardBody>
-        <Styled.Text color="light">{description}</Styled.Text>
+        <Styled.Text color="light" data-testid={`release-card-description`}>
+          {description}
+        </Styled.Text>
       </Styled.CardBody>
     );
 

--- a/ui/src/core/components/Menu/index.tsx
+++ b/ui/src/core/components/Menu/index.tsx
@@ -56,7 +56,11 @@ const Menu = ({
 
   const renderActions = () =>
     map(actions, ({ icon, label, name }: Action) => (
-      <Styled.Action key={name} onClick={() => handleSelect(name)}>
+      <Styled.Action
+        key={name}
+        onClick={() => handleSelect(name)}
+        data-testid={`menu-options-${label}`}
+      >
         <Styled.WrapperIcon>
           {name === active && (
             <Styled.Icon size="15px" color="light" name="checkmark" />

--- a/ui/src/modules/Circles/Comparation/Item/Layer/Components.tsx
+++ b/ui/src/modules/Circles/Comparation/Item/Layer/Components.tsx
@@ -32,7 +32,10 @@ const LayerComponents = ({ components }: Props) => {
     name,
     version
   }: Pick<Component, 'module' | 'name' | 'version'>) => (
-    <Panel.Section key={`${module}-${name}-${version}`}>
+    <Panel.Section
+      key={`${module}-${name}-${version}`}
+      data-testid={`deployed-module-${module}-${name}-${version}`}
+    >
       <Text.h5 color="light">{`${module}/${name}:${version}`}</Text.h5>
     </Panel.Section>
   );

--- a/ui/src/modules/Circles/Matcher/ResultList.tsx
+++ b/ui/src/modules/Circles/Matcher/ResultList.tsx
@@ -44,10 +44,20 @@ const ResultList = ({ isLoading, circles }: Props) => {
         <Styled.CardLeftLine />
         <Styled.CardContent>
           <div>
-            <Text.h5 color="light">{circle.name}</Text.h5>{' '}
+            <Text.h5
+              color="light"
+              data-testid={`circle-matcher-result-${circle.name}`}
+            >
+              {circle.name}
+            </Text.h5>
           </div>
           <div>
-            <Text.h5 color="dark">{circle.id}</Text.h5>
+            <Text.h5
+              color="dark"
+              data-testid={`circle-matcher-result-${circle.id}`}
+            >
+              {circle.id}
+            </Text.h5>
           </div>
           <div>
             <Styled.ButtonOutlineRounded

--- a/ui/src/modules/Settings/Credentials/Sections/MetricAction/Form.tsx
+++ b/ui/src/modules/Settings/Credentials/Sections/MetricAction/Form.tsx
@@ -153,7 +153,7 @@ const FormAddAction = ({ onFinish }: Props) => {
         <Popover
           title="What is a action?"
           icon="info"
-          link={`${CHARLES_DOC}/reference/metrics`}
+          link={`${CHARLES_DOC}/reference/metrics/metrics-actions`}
           linkLabel="View documentation"
           description="You can create an action and add a trigger to perform an automatic task."
         />

--- a/ui/src/modules/Settings/Credentials/Sections/MetricProvider/Form.tsx
+++ b/ui/src/modules/Settings/Credentials/Sections/MetricProvider/Form.tsx
@@ -165,7 +165,7 @@ const FormMetricProvider = ({ onFinish }: Props) => {
         <Popover
           title="Why we ask for Metrics Provider?"
           icon="info"
-          link={`${CHARLES_DOC}/reference/metrics`}
+          link={`${CHARLES_DOC}/reference/metrics/register-metrics-provider`}
           linkLabel="View documentation"
           description="Adding the URL of our tool helps Charles to metrics generation since this can vary from workspace to another. Consult the our documentation for further details."
         />


### PR DESCRIPTION
By default all deployments performed on a circle will always remove the old components.
If everything work as expected we can remove the undeployment call that Moove performs on each deployment since its always handled by Butler.