### PR TITLE
Implementing gitlab ignore certificate errors.

### DIFF
--- a/moove/commons/src/main/kotlin/io/charlescd/moove/commons/integration/git/factory/GitLabClientFactoryLegacy.kt
+++ b/moove/commons/src/main/kotlin/io/charlescd/moove/commons/integration/git/factory/GitLabClientFactoryLegacy.kt
@@ -18,16 +18,22 @@ package io.charlescd.moove.commons.integration.git.factory
 
 import io.charlescd.moove.legacy.repository.entity.GitCredentials
 import org.gitlab4j.api.GitLabApi
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
-class GitLabClientFactoryLegacy {
+class GitLabClientFactoryLegacy(
+    @Value("#{environment.GITLAB_IGNORE_CERTIFICATE_ERRORS ?: false}")
+    val shouldIgnoreCertificateErrors: Boolean
+) {
 
     fun buildGitClient(gitCredentials: GitCredentials): GitLabApi {
         return if (!gitCredentials.accessToken.isNullOrBlank()) {
             GitLabApi(GitLabApi.ApiVersion.V4, gitCredentials.address, gitCredentials.accessToken)
+                .apply { ignoreCertificateErrors = shouldIgnoreCertificateErrors }
         } else {
             GitLabApi.oauth2Login(gitCredentials.address, gitCredentials.username, gitCredentials.password)
+                .apply { ignoreCertificateErrors = shouldIgnoreCertificateErrors }
         }
     }
 }

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/GitLabClientFactory.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/GitLabClientFactory.kt
@@ -2,10 +2,14 @@ package io.charlescd.moove.infrastructure.service
 
 import io.charlescd.moove.domain.GitCredentials
 import org.gitlab4j.api.GitLabApi
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
-class GitLabClientFactory {
+class GitLabClientFactory(
+    @Value("#{environment.GITLAB_IGNORE_CERTIFICATE_ERRORS ?: false}")
+    val shouldIgnoreCertificateErrors: Boolean
+) {
 
     private val defaultAdress = "https://gitlab.com"
 
@@ -16,8 +20,10 @@ class GitLabClientFactory {
         }
         return if (!gitCredentials.accessToken.isNullOrBlank()) {
             GitLabApi(GitLabApi.ApiVersion.V4, address, gitCredentials.accessToken)
+                .apply { ignoreCertificateErrors = shouldIgnoreCertificateErrors }
         } else {
             GitLabApi.oauth2Login(address, gitCredentials.username, gitCredentials.password)
+                .apply { ignoreCertificateErrors = shouldIgnoreCertificateErrors }
         }
     }
 }

--- a/moove/infrastructure/src/test/groovy/io/charlescd/moove/infrastructure/service/GitLabClientFactoryTest.groovy
+++ b/moove/infrastructure/src/test/groovy/io/charlescd/moove/infrastructure/service/GitLabClientFactoryTest.groovy
@@ -27,7 +27,7 @@ class GitLabClientFactoryTest extends Specification {
     private GitLabClientFactory gitLabClientFactory
 
     void setup() {
-        this.gitLabClientFactory = new GitLabClientFactory()
+        this.gitLabClientFactory = new GitLabClientFactory(false)
     }
 
     def "when using OAuth2Token credential should return GitHub client"() {


### PR DESCRIPTION
Fix to ignore certificate errors when integrating with gitlab. If you want to skip certificate errors, just add a environment variable called GITLAB_IGNORE_CERTIFICATE_ERRORS with the value true. The default value is false.


https://github.com/ZupIT/charlescd/pull/395