### PR TITLE
adding crud webhook apis

### DIFF
--- a/moove/api/src/main/kotlin/io/charlescd/moove/api/controller/V2WebhookController.kt
+++ b/moove/api/src/main/kotlin/io/charlescd/moove/api/controller/V2WebhookController.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.api.controller
+
+import io.charlescd.moove.application.webhook.CreateWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.DeleteWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.GetWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.UpdateWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.request.CreateWebhookSubscriptionRequest
+import io.charlescd.moove.application.webhook.request.UpdateWebhookSubscriptionRequest
+import io.charlescd.moove.application.webhook.response.CreateWebhookSubscriptionResponse
+import io.charlescd.moove.application.webhook.response.SimpleWebhookSubscriptionResponse
+import io.swagger.annotations.ApiOperation
+import javax.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/v1/webhooks")
+class V2WebhookController(
+    private val createWebhookSubscriptionInteractor: CreateWebhookSubscriptionInteractor,
+    private val updateWebhookSubscriptionInteractor: UpdateWebhookSubscriptionInteractor,
+    private val getWebhookSubscriptionInteractor: GetWebhookSubscriptionInteractor,
+    private val deleteWebhookSubscriptionInteractor: DeleteWebhookSubscriptionInteractor
+) {
+
+    @ApiOperation(value = "Create a subscribe webhook")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun subscribe(
+        @RequestHeader("x-workspace-id") workspaceId: String,
+        @RequestHeader(value = "Authorization") authorization: String,
+        @Valid @RequestBody request: CreateWebhookSubscriptionRequest
+    ): CreateWebhookSubscriptionResponse {
+        return createWebhookSubscriptionInteractor.execute(workspaceId, authorization, request)
+    }
+
+    @ApiOperation(value = "Get a subscription webhook")
+    @GetMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun getSubscription(
+        @RequestHeader("x-workspace-id") workspaceId: String,
+        @RequestHeader(value = "Authorization") authorization: String,
+        @PathVariable("id") id: String
+    ): SimpleWebhookSubscriptionResponse {
+        return getWebhookSubscriptionInteractor.execute(workspaceId, id, authorization)
+    }
+
+    @ApiOperation(value = "Update a subscription webhook")
+    @PatchMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun updateSubscription(
+        @RequestHeader("x-workspace-id") workspaceId: String,
+        @RequestHeader(value = "Authorization") authorization: String,
+        @PathVariable("id") id: String,
+        @Valid @RequestBody request: UpdateWebhookSubscriptionRequest
+    ): SimpleWebhookSubscriptionResponse {
+        return updateWebhookSubscriptionInteractor.execute(workspaceId, id, authorization, request)
+    }
+
+    @ApiOperation(value = "Delete a subscription webhook")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun deleteSubscription(
+        @RequestHeader("x-workspace-id") workspaceId: String,
+        @RequestHeader(value = "Authorization") authorization: String,
+        @PathVariable("id") id: String
+    ) {
+        deleteWebhookSubscriptionInteractor.execute(workspaceId, id, authorization)
+    }
+}

--- a/moove/api/src/main/kotlin/io/charlescd/moove/api/controller/WebhookController.kt
+++ b/moove/api/src/main/kotlin/io/charlescd/moove/api/controller/WebhookController.kt
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/v1/webhooks")
-class V2WebhookController(
+class WebhookController(
     private val createWebhookSubscriptionInteractor: CreateWebhookSubscriptionInteractor,
     private val updateWebhookSubscriptionInteractor: UpdateWebhookSubscriptionInteractor,
     private val getWebhookSubscriptionInteractor: GetWebhookSubscriptionInteractor,

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/WebhookService.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/WebhookService.kt
@@ -1,67 +1,72 @@
 /*
  *
- *  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *  Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
  */
 
 package io.charlescd.moove.application
 
 import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.User
 import io.charlescd.moove.domain.WebhookSubscription
 import io.charlescd.moove.domain.exceptions.NotFoundException
 import io.charlescd.moove.domain.service.HermesService
-import io.charlescd.moove.domain.service.ManagementUserSecurityService
 import javax.inject.Named
 
 @Named
-class WebhookService(private val hermesService: HermesService, private val userSecurityService: ManagementUserSecurityService) {
+class WebhookService(private val hermesService: HermesService, private val userService: UserService) {
 
     fun subscribe(authorization: String, webhookSubscription: WebhookSubscription): String {
         return hermesService.subscribe(getAuthorEmail(authorization), webhookSubscription)
     }
 
     fun getSubscription(workspaceId: String, authorization: String, id: String): SimpleWebhookSubscription {
-        val authorEmail = getAuthorEmail(authorization)
-        return getSubscriptionByIdAndWorkspace(workspaceId, authorEmail, id)
-    }
-
-    fun updateSubscription(workspaceId: String, authorization: String, id: String, events: List<String>): SimpleWebhookSubscription {
-        val authorEmail = getAuthorEmail(authorization)
-        getSubscriptionByIdAndWorkspace(workspaceId, authorEmail, id)
-        return hermesService.updateSubscription(authorEmail, id, events)
-    }
-
-    fun deleteSubscription(workspaceId: String, authorization: String, id: String) {
-        val authorEmail = getAuthorEmail(authorization)
-        getSubscriptionByIdAndWorkspace(workspaceId, authorEmail, id)
-        hermesService.deleteSubscription(authorEmail, id)
-    }
-
-    private fun getAuthorEmail(authorization: String): String {
-        return userSecurityService.getUserEmail(authorization)
-    }
-
-    private fun getSubscriptionByIdAndWorkspace(workspaceId: String, authorEmail: String, id: String): SimpleWebhookSubscription {
-        val subscription = hermesService.getSubscription(authorEmail, id)
-        validateWorkspace(workspaceId, id, subscription)
+        val author = getAuthor(authorization)
+        val subscription = hermesService.getSubscription(author.email, id)
+        validateWorkspace(workspaceId, id, author, subscription)
         return subscription
     }
 
-    private fun validateWorkspace(workspaceId: String, id: String, subscription: SimpleWebhookSubscription) {
-        if (subscription.workspaceId != workspaceId) {
+    fun updateSubscription(workspaceId: String, authorization: String, id: String, events: List<String>): SimpleWebhookSubscription {
+        val author = getAuthor(authorization)
+        validateSubscription(workspaceId, author, id)
+        return hermesService.updateSubscription(author.email, id, events)
+    }
+
+    fun deleteSubscription(workspaceId: String, authorization: String, id: String) {
+        val author = getAuthor(authorization)
+        validateSubscription(workspaceId, author, id)
+        hermesService.deleteSubscription(author.email, id)
+    }
+
+    private fun getAuthor(authorization: String): User {
+        return userService.findByAuthorizationToken(authorization)
+    }
+
+    private fun getAuthorEmail(authorization: String): String {
+        return userService.getEmailFromToken(authorization)
+    }
+
+    private fun validateWorkspace(workspaceId: String, id: String, author: User, subscription: SimpleWebhookSubscription) {
+        if (!author.root && subscription.workspaceId != workspaceId) {
             throw NotFoundException("subscription", id)
         }
+    }
+
+    private fun validateSubscription(workspaceId: String, author: User, id: String) {
+        val subscription = hermesService.getSubscription(author.email, id)
+        validateWorkspace(workspaceId, id, author, subscription)
     }
 }

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/WebhookService.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/WebhookService.kt
@@ -1,0 +1,67 @@
+/*
+ *
+ *  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package io.charlescd.moove.application
+
+import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.WebhookSubscription
+import io.charlescd.moove.domain.exceptions.NotFoundException
+import io.charlescd.moove.domain.service.HermesService
+import io.charlescd.moove.domain.service.ManagementUserSecurityService
+import javax.inject.Named
+
+@Named
+class WebhookService(private val hermesService: HermesService, private val userSecurityService: ManagementUserSecurityService) {
+
+    fun subscribe(authorization: String, webhookSubscription: WebhookSubscription): String {
+        return hermesService.subscribe(getAuthorEmail(authorization), webhookSubscription)
+    }
+
+    fun getSubscription(workspaceId: String, authorization: String, id: String): SimpleWebhookSubscription {
+        val authorEmail = getAuthorEmail(authorization)
+        return getSubscriptionByIdAndWorkspace(workspaceId, authorEmail, id)
+    }
+
+    fun updateSubscription(workspaceId: String, authorization: String, id: String, events: List<String>): SimpleWebhookSubscription {
+        val authorEmail = getAuthorEmail(authorization)
+        getSubscriptionByIdAndWorkspace(workspaceId, authorEmail, id)
+        return hermesService.updateSubscription(authorEmail, id, events)
+    }
+
+    fun deleteSubscription(workspaceId: String, authorization: String, id: String) {
+        val authorEmail = getAuthorEmail(authorization)
+        getSubscriptionByIdAndWorkspace(workspaceId, authorEmail, id)
+        hermesService.deleteSubscription(authorEmail, id)
+    }
+
+    private fun getAuthorEmail(authorization: String): String {
+        return userSecurityService.getUserEmail(authorization)
+    }
+
+    private fun getSubscriptionByIdAndWorkspace(workspaceId: String, authorEmail: String, id: String): SimpleWebhookSubscription {
+        val subscription = hermesService.getSubscription(authorEmail, id)
+        validateWorkspace(workspaceId, id, subscription)
+        return subscription
+    }
+
+    private fun validateWorkspace(workspaceId: String, id: String, subscription: SimpleWebhookSubscription) {
+        if (subscription.workspaceId != workspaceId) {
+            throw NotFoundException("subscription", id)
+        }
+    }
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/CreateWebhookSubscriptionInteractor.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/CreateWebhookSubscriptionInteractor.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook
+
+import io.charlescd.moove.application.webhook.request.CreateWebhookSubscriptionRequest
+import io.charlescd.moove.application.webhook.response.CreateWebhookSubscriptionResponse
+
+interface CreateWebhookSubscriptionInteractor {
+    fun execute(workspaceId: String, authorization: String, request: CreateWebhookSubscriptionRequest): CreateWebhookSubscriptionResponse
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/DeleteWebhookSubscriptionInteractor.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/DeleteWebhookSubscriptionInteractor.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook
+
+interface DeleteWebhookSubscriptionInteractor {
+    fun execute(workspaceId: String, id: String, authorization: String)
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/GetWebhookSubscriptionInteractor.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/GetWebhookSubscriptionInteractor.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook
+
+import io.charlescd.moove.application.webhook.response.SimpleWebhookSubscriptionResponse
+
+interface GetWebhookSubscriptionInteractor {
+    fun execute(workspaceId: String, id: String, authorization: String): SimpleWebhookSubscriptionResponse
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/UpdateWebhookSubscriptionInteractor.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/UpdateWebhookSubscriptionInteractor.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook
+
+import io.charlescd.moove.application.webhook.request.UpdateWebhookSubscriptionRequest
+import io.charlescd.moove.application.webhook.response.SimpleWebhookSubscriptionResponse
+
+interface UpdateWebhookSubscriptionInteractor {
+    fun execute(workspaceId: String, id: String, authorization: String, request: UpdateWebhookSubscriptionRequest): SimpleWebhookSubscriptionResponse
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/CreateWebhookSubscriptionInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/CreateWebhookSubscriptionInteractorImpl.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.CreateWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.request.CreateWebhookSubscriptionRequest
+import io.charlescd.moove.application.webhook.response.CreateWebhookSubscriptionResponse
+import javax.inject.Inject
+import javax.inject.Named
+
+@Named
+class CreateWebhookSubscriptionInteractorImpl @Inject constructor(
+    private val webhookService: WebhookService
+) : CreateWebhookSubscriptionInteractor {
+
+    override fun execute(workspaceId: String, authorization: String, request: CreateWebhookSubscriptionRequest): CreateWebhookSubscriptionResponse {
+        val webhookSubscriptionId = webhookService.subscribe(authorization, request.toWebhookSubscription(workspaceId))
+        return CreateWebhookSubscriptionResponse.from(webhookSubscriptionId)
+    }
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/DeleteWebhookSubscriptionInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/DeleteWebhookSubscriptionInteractorImpl.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.DeleteWebhookSubscriptionInteractor
+import javax.inject.Inject
+import javax.inject.Named
+
+@Named
+class DeleteWebhookSubscriptionInteractorImpl @Inject constructor(
+    private val webhookService: WebhookService
+) : DeleteWebhookSubscriptionInteractor {
+    override fun execute(workspaceId: String, id: String, authorization: String) {
+        val webhookSubscription = webhookService.deleteSubscription(workspaceId, authorization, id)
+    }
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/GetWebhookSubscriptionInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/GetWebhookSubscriptionInteractorImpl.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.GetWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.response.SimpleWebhookSubscriptionResponse
+import javax.inject.Inject
+import javax.inject.Named
+
+@Named
+class GetWebhookSubscriptionInteractorImpl @Inject constructor(
+    private val webhookService: WebhookService
+) : GetWebhookSubscriptionInteractor {
+    override fun execute(workspaceId: String, id: String, authorization: String): SimpleWebhookSubscriptionResponse {
+        val webhookSubscription = webhookService.getSubscription(workspaceId, authorization, id)
+        return SimpleWebhookSubscriptionResponse.from(webhookSubscription)
+    }
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/UpdateWebhookSubscriptionInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/impl/UpdateWebhookSubscriptionInteractorImpl.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.UpdateWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.request.UpdateWebhookSubscriptionRequest
+import io.charlescd.moove.application.webhook.response.SimpleWebhookSubscriptionResponse
+import javax.inject.Inject
+import javax.inject.Named
+
+@Named
+class UpdateWebhookSubscriptionInteractorImpl @Inject constructor(
+    private val webhookService: WebhookService
+) : UpdateWebhookSubscriptionInteractor {
+    override fun execute(workspaceId: String, id: String, authorization: String, request: UpdateWebhookSubscriptionRequest): SimpleWebhookSubscriptionResponse {
+        val webhookSubscription = webhookService.updateSubscription(workspaceId, authorization, id, request.events)
+        return SimpleWebhookSubscriptionResponse.from(webhookSubscription)
+    }
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/request/CreateWebhookSubscriptionRequest.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/request/CreateWebhookSubscriptionRequest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.request
+
+import io.charlescd.moove.domain.WebhookSubscription
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotEmpty
+
+data class CreateWebhookSubscriptionRequest(
+    @field:NotBlank
+    val url: String,
+    val apiKey: String,
+    @field:NotBlank
+    val description: String,
+    @field:NotEmpty
+    val events: List<String>
+) {
+    fun toWebhookSubscription(workspaceId: String) = WebhookSubscription(
+        description = description,
+        url = url,
+        apiKey = apiKey,
+        events = events,
+        workspaceId = workspaceId
+    )
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/request/UpdateWebhookSubscriptionRequest.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/request/UpdateWebhookSubscriptionRequest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.request
+
+data class UpdateWebhookSubscriptionRequest(
+    val events: List<String>
+)

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/response/CreateWebhookSubscriptionResponse.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/response/CreateWebhookSubscriptionResponse.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.response
+
+data class CreateWebhookSubscriptionResponse(
+    val id: String
+) {
+    companion object {
+        fun from(id: String) = CreateWebhookSubscriptionResponse(
+            id = id
+        )
+    }
+}

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/response/SimpleWebhookSubscriptionResponse.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/webhook/response/SimpleWebhookSubscriptionResponse.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.response
+
+import io.charlescd.moove.domain.SimpleWebhookSubscription
+
+data class SimpleWebhookSubscriptionResponse(
+    val url: String,
+    val workspaceId: String,
+    val description: String,
+    val events: List<String>
+) {
+    companion object {
+        fun from(webhookSubscription: SimpleWebhookSubscription) = SimpleWebhookSubscriptionResponse(
+            url = webhookSubscription.url,
+            description = webhookSubscription.description,
+            workspaceId = webhookSubscription.workspaceId,
+            events = webhookSubscription.events
+        )
+    }
+}

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/WebhookServiceTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/WebhookServiceTest.groovy
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.WebhookSubscription
+import io.charlescd.moove.domain.exceptions.NotFoundException
+import io.charlescd.moove.domain.service.HermesService
+import io.charlescd.moove.domain.service.ManagementUserSecurityService
+import spock.lang.Specification
+
+class WebhookServiceTest extends Specification {
+
+    private WebhookService webhookService
+
+    private HermesService hermesService = Mock(HermesService)
+    private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
+
+    void setup() {
+        this.webhookService = new WebhookService(hermesService, managementUserSecurityService)
+    }
+
+    def "when create webhook subscription should not throw"() {
+        given:
+        def subscription = new WebhookSubscription( 'https://mywebhook.com.br', 'secret', 'workspaceId',
+                'My Webhook', events)
+
+        when:
+        this.webhookService.subscribe(authorization, subscription)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.subscribe(authorEmail, subscription) >> "subscriptionId"
+
+        notThrown()
+    }
+
+    def "when get webhook subscription should not throw"() {
+        when:
+        this.webhookService.getSubscription(workspaceId, authorization, subscriptionId)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+
+        notThrown()
+    }
+
+    def "when get webhook subscription and workspaceId is wrong, should throw NotFoundException"() {
+        when:
+        this.webhookService.getSubscription("workspaceIdOther", authorization, subscriptionId)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+
+        thrown(NotFoundException)
+    }
+
+    def "when update webhook subscription should not throw"() {
+        when:
+        this.webhookService.updateSubscription(workspaceId, authorization, subscriptionId, events)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        1 * this.hermesService.updateSubscription(authorEmail, subscriptionId, events) >> simpleWebhookSubscription
+
+        notThrown()
+    }
+
+    def "when update webhook subscription and workspaceId is wrong, should not update and throw NotFoundException"() {
+        when:
+        this.webhookService.getSubscription("workspaceIdOther", authorization, subscriptionId)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        0 * this.hermesService.updateSubscription(authorEmail, subscriptionId, events) >> simpleWebhookSubscription
+
+        thrown(NotFoundException)
+    }
+
+    def "when delete webhook subscription should not throw"() {
+        when:
+        this.webhookService.deleteSubscription(workspaceId, authorization, subscriptionId)
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        1 * this.hermesService.deleteSubscription(authorEmail, subscriptionId)
+
+        notThrown()
+    }
+
+    def "when delete webhook subscription and workspaceId is wrong, should not update and throw NotFoundException"() {
+        when:
+        this.webhookService.deleteSubscription("workspaceIdOther", authorization, subscriptionId)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        0 * this.hermesService.deleteSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+
+        thrown(NotFoundException)
+    }
+
+    private static List<String> getEvents() {
+        def events = new ArrayList()
+        events.add("DEPLOY")
+        return events
+    }
+
+    private static String getAuthorEmail() {
+        return "email@email.com"
+    }
+
+    private static String getAuthorization() {
+        return "Bearer qwerty"
+    }
+
+    private static String getWorkspaceId() {
+        return "workspaceId"
+    }
+
+    private static String getSubscriptionId() {
+        return "subscriptionId"
+    }
+
+    private static SimpleWebhookSubscription getSimpleWebhookSubscription() {
+        return new SimpleWebhookSubscription('https://mywebhook.com.br', 'workspaceId',
+                'My Webhook', events)
+    }
+}

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/CreateWebhookSubscriptionInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/CreateWebhookSubscriptionInteractorImplTest.groovy
@@ -16,10 +16,12 @@
 
 package io.charlescd.moove.application.webhook.impl
 
+import io.charlescd.moove.application.UserService
 import io.charlescd.moove.application.WebhookService
 import io.charlescd.moove.application.webhook.CreateWebhookSubscriptionInteractor
 import io.charlescd.moove.application.webhook.request.CreateWebhookSubscriptionRequest
 import io.charlescd.moove.domain.WebhookSubscription
+import io.charlescd.moove.domain.repository.UserRepository
 import io.charlescd.moove.domain.service.HermesService
 import io.charlescd.moove.domain.service.ManagementUserSecurityService
 import spock.lang.Specification
@@ -29,10 +31,11 @@ class CreateWebhookSubscriptionInteractorImplTest extends Specification {
 
     private CreateWebhookSubscriptionInteractor createWebhookSubscriptionInteractor
     private HermesService hermesService = Mock(HermesService)
+    private UserRepository userRepository = Mock(UserRepository)
     private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
 
     def setup() {
-        createWebhookSubscriptionInteractor = new CreateWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, managementUserSecurityService))
+        createWebhookSubscriptionInteractor = new CreateWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, new UserService(userRepository, managementUserSecurityService)))
     }
 
     def "when trying to create subscription should do it successfully"() {

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/CreateWebhookSubscriptionInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/CreateWebhookSubscriptionInteractorImplTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.CreateWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.request.CreateWebhookSubscriptionRequest
+import io.charlescd.moove.domain.WebhookSubscription
+import io.charlescd.moove.domain.service.HermesService
+import io.charlescd.moove.domain.service.ManagementUserSecurityService
+import spock.lang.Specification
+
+
+class CreateWebhookSubscriptionInteractorImplTest extends Specification {
+
+    private CreateWebhookSubscriptionInteractor createWebhookSubscriptionInteractor
+    private HermesService hermesService = Mock(HermesService)
+    private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
+
+    def setup() {
+        createWebhookSubscriptionInteractor = new CreateWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, managementUserSecurityService))
+    }
+
+    def "when trying to create subscription should do it successfully"() {
+        when:
+        createWebhookSubscriptionInteractor.execute(workspaceId, authorization, createWebhookSubscriptionRequest)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.subscribe(authorEmail, webhookSubscription) >> subscriptionId
+
+        notThrown()
+    }
+
+
+    private static List<String> getEvents() {
+        def events = new ArrayList()
+        events.add("DEPLOY")
+        return events
+    }
+
+    private static String getAuthorEmail() {
+        return "email@email.com"
+    }
+
+    private static String getAuthorization() {
+        return "Bearer qwerty"
+    }
+
+    private static String getWorkspaceId() {
+        return "workspaceId"
+    }
+
+    private static String getSubscriptionId() {
+        return "subscriptionId"
+    }
+
+    private static CreateWebhookSubscriptionRequest getCreateWebhookSubscriptionRequest() {
+        return new CreateWebhookSubscriptionRequest('https://mywebhook.com.br', 'secret',
+                'My Webhook', events)
+    }
+
+    private static WebhookSubscription getWebhookSubscription() {
+        return new WebhookSubscription('https://mywebhook.com.br', 'secret', 'workspaceId',
+                'My Webhook', events)
+    }
+}

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/DeleteWebhookSubscriptionInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/DeleteWebhookSubscriptionInteractorImplTest.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.DeleteWebhookSubscriptionInteractor
+import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.exceptions.NotFoundException
+import io.charlescd.moove.domain.service.HermesService
+import io.charlescd.moove.domain.service.ManagementUserSecurityService
+import spock.lang.Specification
+
+class DeleteWebhookSubscriptionInteractorImplTest extends Specification {
+
+    private DeleteWebhookSubscriptionInteractor deleteWebhookSubscriptionInteractor
+    private HermesService hermesService = Mock(HermesService)
+    private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
+
+    def setup() {
+        deleteWebhookSubscriptionInteractor = new DeleteWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, managementUserSecurityService))
+    }
+
+    def "when trying to delete subscription should do it successfully"() {
+        when:
+        deleteWebhookSubscriptionInteractor.execute(workspaceId, subscriptionId, authorization)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        1 * this.hermesService.deleteSubscription(authorEmail, subscriptionId)
+        notThrown()
+    }
+
+    def "when trying to delete subscription and is wrong workspace should throw not found exception"() {
+        when:
+        deleteWebhookSubscriptionInteractor.execute("workspaceIdOther", subscriptionId, authorization)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        0 * this.hermesService.deleteSubscription(authorEmail, subscriptionId)
+        thrown(NotFoundException)
+    }
+
+    private static List<String> getEvents() {
+        def events = new ArrayList()
+        events.add("DEPLOY")
+        return events
+    }
+
+    private static String getAuthorEmail() {
+        return "email@email.com"
+    }
+
+    private static String getAuthorization() {
+        return "Bearer qwerty"
+    }
+
+    private static String getWorkspaceId() {
+        return "workspaceId"
+    }
+
+    private static String getSubscriptionId() {
+        return "subscriptionId"
+    }
+
+    private static SimpleWebhookSubscription getSimpleWebhookSubscription() {
+        return new SimpleWebhookSubscription('https://mywebhook.com.br', 'workspaceId',
+                'My Webhook', events)
+    }
+}

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/DeleteWebhookSubscriptionInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/DeleteWebhookSubscriptionInteractorImplTest.groovy
@@ -16,22 +16,28 @@
 
 package io.charlescd.moove.application.webhook.impl
 
+import io.charlescd.moove.application.UserService
 import io.charlescd.moove.application.WebhookService
 import io.charlescd.moove.application.webhook.DeleteWebhookSubscriptionInteractor
 import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.User
 import io.charlescd.moove.domain.exceptions.NotFoundException
+import io.charlescd.moove.domain.repository.UserRepository
 import io.charlescd.moove.domain.service.HermesService
 import io.charlescd.moove.domain.service.ManagementUserSecurityService
 import spock.lang.Specification
+
+import java.time.LocalDateTime
 
 class DeleteWebhookSubscriptionInteractorImplTest extends Specification {
 
     private DeleteWebhookSubscriptionInteractor deleteWebhookSubscriptionInteractor
     private HermesService hermesService = Mock(HermesService)
+    private UserRepository userRepository = Mock(UserRepository)
     private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
 
     def setup() {
-        deleteWebhookSubscriptionInteractor = new DeleteWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, managementUserSecurityService))
+        deleteWebhookSubscriptionInteractor = new DeleteWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, new UserService(userRepository, managementUserSecurityService)))
     }
 
     def "when trying to delete subscription should do it successfully"() {
@@ -40,6 +46,7 @@ class DeleteWebhookSubscriptionInteractorImplTest extends Specification {
 
         then:
         1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.userRepository.findByEmail(authorEmail) >> Optional.of(author)
         1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
         1 * this.hermesService.deleteSubscription(authorEmail, subscriptionId)
         notThrown()
@@ -51,6 +58,7 @@ class DeleteWebhookSubscriptionInteractorImplTest extends Specification {
 
         then:
         1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.userRepository.findByEmail(authorEmail) >> Optional.of(author)
         1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
         0 * this.hermesService.deleteSubscription(authorEmail, subscriptionId)
         thrown(NotFoundException)
@@ -64,6 +72,11 @@ class DeleteWebhookSubscriptionInteractorImplTest extends Specification {
 
     private static String getAuthorEmail() {
         return "email@email.com"
+    }
+
+    private static User getAuthor() {
+        return new User("f52f94b8-6775-470f-bac8-125ebfd6b636", "charlescd", authorEmail, "http://image.com.br/photo.png",
+                [], false, LocalDateTime.now())
     }
 
     private static String getAuthorization() {

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/GetWebhookSubscriptionInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/GetWebhookSubscriptionInteractorImplTest.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.GetWebhookSubscriptionInteractor
+import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.exceptions.NotFoundException
+import io.charlescd.moove.domain.service.HermesService
+import io.charlescd.moove.domain.service.ManagementUserSecurityService
+import spock.lang.Specification
+
+class GetWebhookSubscriptionInteractorImplTest extends Specification {
+
+    private GetWebhookSubscriptionInteractor getWebhookSubscriptionInteractor
+    private HermesService hermesService = Mock(HermesService)
+    private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
+
+    def setup() {
+        getWebhookSubscriptionInteractor = new GetWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, managementUserSecurityService))
+    }
+
+    def "when trying to get subscription should do it successfully"() {
+        when:
+        getWebhookSubscriptionInteractor.execute(workspaceId, subscriptionId, authorization)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+
+        notThrown()
+    }
+
+    def "when trying to get subscription and is wrong workspace should throw not found exception"() {
+        when:
+        getWebhookSubscriptionInteractor.execute("workspaceIdOther", subscriptionId, authorization)
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+
+        thrown(NotFoundException)
+    }
+
+    private static List<String> getEvents() {
+        def events = new ArrayList()
+        events.add("DEPLOY")
+        return events
+    }
+
+    private static String getAuthorEmail() {
+        return "email@email.com"
+    }
+
+    private static String getAuthorization() {
+        return "Bearer qwerty"
+    }
+
+    private static String getWorkspaceId() {
+        return "workspaceId"
+    }
+
+    private static String getSubscriptionId() {
+        return "subscriptionId"
+    }
+
+    private static SimpleWebhookSubscription getSimpleWebhookSubscription() {
+        return new SimpleWebhookSubscription('https://mywebhook.com.br', 'workspaceId',
+                'My Webhook', events)
+    }
+}

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/UpdateWebhookSubscriptionInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/UpdateWebhookSubscriptionInteractorImplTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.application.webhook.impl
+
+import io.charlescd.moove.application.WebhookService
+import io.charlescd.moove.application.webhook.UpdateWebhookSubscriptionInteractor
+import io.charlescd.moove.application.webhook.request.UpdateWebhookSubscriptionRequest
+import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.exceptions.NotFoundException
+import io.charlescd.moove.domain.service.HermesService
+import io.charlescd.moove.domain.service.ManagementUserSecurityService
+import spock.lang.Specification
+
+class UpdateWebhookSubscriptionInteractorImplTest extends Specification {
+
+    private UpdateWebhookSubscriptionInteractor updateWebhookSubscriptionInteractor
+    private HermesService hermesService = Mock(HermesService)
+    private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
+
+    def setup() {
+        updateWebhookSubscriptionInteractor = new UpdateWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, managementUserSecurityService))
+    }
+
+    def "when trying to update subscription should do it successfully"() {
+        when:
+        updateWebhookSubscriptionInteractor.execute(workspaceId, subscriptionId, authorization, updateWebhookSubscriptionRequest())
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        1 * this.hermesService.updateSubscription(authorEmail, subscriptionId, events) >> simpleWebhookSubscription
+        notThrown()
+    }
+
+    def "when trying to update subscription and is wrong workspace should throw not found exception"() {
+        when:
+        updateWebhookSubscriptionInteractor.execute("workspaceIdOther", subscriptionId, authorization, updateWebhookSubscriptionRequest())
+
+        then:
+        1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
+        0 * this.hermesService.updateSubscription(authorEmail, subscriptionId, events) >> simpleWebhookSubscription
+
+        thrown(NotFoundException)
+    }
+
+    private static List<String> getEvents() {
+        def events = new ArrayList()
+        events.add("DEPLOY")
+        return events
+    }
+
+    private static String getAuthorEmail() {
+        return "email@email.com"
+    }
+
+    private static String getAuthorization() {
+        return "Bearer qwerty"
+    }
+
+    private static String getWorkspaceId() {
+        return "workspaceId"
+    }
+
+    private static String getSubscriptionId() {
+        return "subscriptionId"
+    }
+
+    private static SimpleWebhookSubscription getSimpleWebhookSubscription() {
+        return new SimpleWebhookSubscription('https://mywebhook.com.br', 'workspaceId',
+                'My Webhook', events)
+    }
+
+    private static UpdateWebhookSubscriptionRequest updateWebhookSubscriptionRequest() {
+        return new UpdateWebhookSubscriptionRequest(events)
+    }
+}

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/UpdateWebhookSubscriptionInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/webhook/impl/UpdateWebhookSubscriptionInteractorImplTest.groovy
@@ -16,23 +16,29 @@
 
 package io.charlescd.moove.application.webhook.impl
 
+import io.charlescd.moove.application.UserService
 import io.charlescd.moove.application.WebhookService
 import io.charlescd.moove.application.webhook.UpdateWebhookSubscriptionInteractor
 import io.charlescd.moove.application.webhook.request.UpdateWebhookSubscriptionRequest
 import io.charlescd.moove.domain.SimpleWebhookSubscription
+import io.charlescd.moove.domain.User
 import io.charlescd.moove.domain.exceptions.NotFoundException
+import io.charlescd.moove.domain.repository.UserRepository
 import io.charlescd.moove.domain.service.HermesService
 import io.charlescd.moove.domain.service.ManagementUserSecurityService
 import spock.lang.Specification
+
+import java.time.LocalDateTime
 
 class UpdateWebhookSubscriptionInteractorImplTest extends Specification {
 
     private UpdateWebhookSubscriptionInteractor updateWebhookSubscriptionInteractor
     private HermesService hermesService = Mock(HermesService)
+    private UserRepository userRepository = Mock(UserRepository)
     private ManagementUserSecurityService managementUserSecurityService = Mock(ManagementUserSecurityService)
 
     def setup() {
-        updateWebhookSubscriptionInteractor = new UpdateWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, managementUserSecurityService))
+        updateWebhookSubscriptionInteractor = new UpdateWebhookSubscriptionInteractorImpl(new WebhookService(hermesService, new UserService(userRepository, managementUserSecurityService)))
     }
 
     def "when trying to update subscription should do it successfully"() {
@@ -41,6 +47,7 @@ class UpdateWebhookSubscriptionInteractorImplTest extends Specification {
 
         then:
         1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.userRepository.findByEmail(authorEmail) >> Optional.of(author)
         1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
         1 * this.hermesService.updateSubscription(authorEmail, subscriptionId, events) >> simpleWebhookSubscription
         notThrown()
@@ -52,6 +59,7 @@ class UpdateWebhookSubscriptionInteractorImplTest extends Specification {
 
         then:
         1 * this.managementUserSecurityService.getUserEmail(authorization) >> authorEmail
+        1 * this.userRepository.findByEmail(authorEmail) >> Optional.of(author)
         1 * this.hermesService.getSubscription(authorEmail, subscriptionId) >> simpleWebhookSubscription
         0 * this.hermesService.updateSubscription(authorEmail, subscriptionId, events) >> simpleWebhookSubscription
 
@@ -66,6 +74,11 @@ class UpdateWebhookSubscriptionInteractorImplTest extends Specification {
 
     private static String getAuthorEmail() {
         return "email@email.com"
+    }
+
+    private static User getAuthor() {
+        return new User("f52f94b8-6775-470f-bac8-125ebfd6b636", "charlescd", authorEmail, "http://image.com.br/photo.png",
+                [], false, LocalDateTime.now())
     }
 
     private static String getAuthorization() {

--- a/moove/domain/src/main/kotlin/io/charlescd/moove/domain/WebhookSubscription.kt
+++ b/moove/domain/src/main/kotlin/io/charlescd/moove/domain/WebhookSubscription.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.domain
+
+data class WebhookSubscription(
+    val url: String,
+    val apiKey: String,
+    val workspaceId: String,
+    val description: String,
+    val events: List<String>
+)
+
+data class SimpleWebhookSubscription(
+    val url: String,
+    val workspaceId: String,
+    val description: String,
+    val events: List<String>
+)

--- a/moove/domain/src/main/kotlin/io/charlescd/moove/domain/service/HermesService.kt
+++ b/moove/domain/src/main/kotlin/io/charlescd/moove/domain/service/HermesService.kt
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package io.charlescd.moove.domain.service
+
+import io.charlescd.moove.domain.*
+
+interface HermesService {
+
+    fun subscribe(authorEmail: String, webhookSubscription: WebhookSubscription): String
+
+    fun getSubscription(authorEmail: String, id: String): SimpleWebhookSubscription
+
+    fun updateSubscription(authorEmail: String, id: String, events: List<String>): SimpleWebhookSubscription
+
+    fun deleteSubscription(authorEmail: String, id: String)
+
+    fun getSubscriptionHistory() // TODO Implement
+
+    fun publishSubscription() // TODO Implement
+}

--- a/moove/domain/src/main/kotlin/io/charlescd/moove/domain/service/HermesService.kt
+++ b/moove/domain/src/main/kotlin/io/charlescd/moove/domain/service/HermesService.kt
@@ -1,18 +1,18 @@
 /*
  *
- *  * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *  Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
  */
 

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/HermesClientService.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/HermesClientService.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.infrastructure.service
+
+import io.charlescd.moove.domain.*
+import io.charlescd.moove.domain.service.HermesService
+import io.charlescd.moove.infrastructure.service.client.*
+import io.charlescd.moove.infrastructure.service.client.request.*
+import io.charlescd.moove.infrastructure.service.client.response.HermesSubscriptionResponse
+import org.springframework.stereotype.Service
+
+@Service
+class HermesClientService(private val hermesClient: HermesClient) : HermesService {
+    override fun subscribe(authorEmail: String, webhookSubscription: WebhookSubscription): String {
+        val request = buildHermesSubscriptionCreateRequest(webhookSubscription)
+        return hermesClient.subscribe(authorEmail, request).id
+    }
+
+    override fun getSubscription(authorEmail: String, id: String): SimpleWebhookSubscription {
+        val subscription = hermesClient.getSubscription(authorEmail, id)
+        return buildSimpleWebhookSubscription(subscription)
+    }
+
+    override fun updateSubscription(authorEmail: String, id: String, events: List<String>): SimpleWebhookSubscription {
+        val request = buildHermesSubscriptionUpdateRequest(events)
+        val subscription = hermesClient.updateSubscription(authorEmail, id, request)
+        return buildSimpleWebhookSubscription(subscription)
+    }
+
+    override fun deleteSubscription(authorEmail: String, id: String) {
+        hermesClient.deleteSubscription(authorEmail, id)
+    }
+
+    override fun getSubscriptionHistory() {
+        TODO("Not yet implemented")
+    }
+
+    override fun publishSubscription() {
+        TODO("Not yet implemented")
+    }
+
+    private fun buildHermesSubscriptionCreateRequest(webhookSubscription: WebhookSubscription): HermesSubscriptionCreateRequest {
+        return HermesSubscriptionCreateRequest(
+            url = webhookSubscription.url,
+            description = webhookSubscription.description,
+            apiKey = webhookSubscription.apiKey,
+            externalId = webhookSubscription.workspaceId,
+            events = webhookSubscription.events
+        )
+    }
+
+    private fun buildHermesSubscriptionUpdateRequest(events: List<String>): HermesSubscriptionUpdateRequest {
+        return HermesSubscriptionUpdateRequest(
+            events = events
+        )
+    }
+
+    private fun buildSimpleWebhookSubscription(subscription: HermesSubscriptionResponse): SimpleWebhookSubscription {
+        return SimpleWebhookSubscription(
+            url = subscription.url,
+            description = subscription.description,
+            workspaceId = subscription.externalId,
+            events = subscription.events
+        )
+    }
+}

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/HermesClient.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/HermesClient.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.infrastructure.service.client
+
+import io.charlescd.moove.infrastructure.configuration.SimpleFeignEncoderConfiguration
+import io.charlescd.moove.infrastructure.service.client.request.HermesSubscriptionCreateRequest
+import io.charlescd.moove.infrastructure.service.client.request.HermesSubscriptionUpdateRequest
+import io.charlescd.moove.infrastructure.service.client.response.*
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.*
+
+@FeignClient(name = "hermesClient", url = "\${charlescd.hermes.url}", configuration = [ SimpleFeignEncoderConfiguration::class])
+interface HermesClient {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(
+        value = ["/subscriptions"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun subscribe(
+        @RequestHeader("x-author") authorEmail: String,
+        @RequestBody request: HermesSubscriptionCreateRequest
+    ): HermesSubscriptionCreateResponse
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping(
+        value = ["/subscriptions/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun updateSubscription(
+        @RequestHeader("x-author") authorEmail: String,
+        @PathVariable("id") id: String,
+        @RequestBody request: HermesSubscriptionUpdateRequest
+    ): HermesSubscriptionResponse
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping(
+        value = ["/subscriptions/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun getSubscription(
+        @RequestHeader("x-author") authorEmail: String,
+        @PathVariable("id") id: String
+    ): HermesSubscriptionResponse
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping(
+        value = ["/subscriptions/{id}"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun deleteSubscription(
+        @RequestHeader("x-author") authorEmail: String,
+        @PathVariable("id") id: String
+    )
+}

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/request/HermesSubscriptionCreateRequest.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/request/HermesSubscriptionCreateRequest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.infrastructure.service.client.request
+
+data class HermesSubscriptionCreateRequest(
+    val url: String,
+    val apiKey: String,
+    val externalId: String,
+    val description: String,
+    val events: List<String>
+)

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/request/HermesSubscriptionUpdateRequest.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/request/HermesSubscriptionUpdateRequest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.infrastructure.service.client.request
+
+data class HermesSubscriptionUpdateRequest(
+    val events: List<String>
+)

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/HermesSubscriptionCreateResponse.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/HermesSubscriptionCreateResponse.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.infrastructure.service.client.response
+
+data class HermesSubscriptionCreateResponse(
+    val id: String
+)

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/HermesSubscriptionResponse.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/HermesSubscriptionResponse.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.infrastructure.service.client.response
+
+data class HermesSubscriptionResponse(
+    val url: String,
+    val apiKey: String,
+    val externalId: String,
+    val description: String,
+    val events: List<String>
+)

--- a/moove/infrastructure/src/test/groovy/io/charlescd/moove/infrastructure/service/HermesClientServiceTest.groovy
+++ b/moove/infrastructure/src/test/groovy/io/charlescd/moove/infrastructure/service/HermesClientServiceTest.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.charlescd.moove.infrastructure.service
+
+import io.charlescd.moove.domain.*
+import io.charlescd.moove.infrastructure.service.client.HermesClient
+import io.charlescd.moove.infrastructure.service.client.request.HermesSubscriptionCreateRequest
+import io.charlescd.moove.infrastructure.service.client.request.HermesSubscriptionUpdateRequest
+import io.charlescd.moove.infrastructure.service.client.response.HermesSubscriptionCreateResponse
+import io.charlescd.moove.infrastructure.service.client.response.HermesSubscriptionResponse
+import spock.lang.Specification
+
+class HermesClientServiceTest extends Specification {
+
+    private HermesClientService hermesService
+    private HermesClient hermesClient = Mock(HermesClient)
+
+    def setup() {
+        hermesService = new HermesClientService(hermesClient)
+    }
+
+    def 'when creating a subscription, should do it successfully'() {
+        given:
+        def request = new HermesSubscriptionCreateRequest('https://mywebhook.com.br', 'secret', 'workspaceId',
+                'My Webhook', events)
+        def subscription = new WebhookSubscription('https://mywebhook.com.br', 'secret', 'workspaceId',
+                'My Webhook', events)
+        def response = new HermesSubscriptionCreateResponse("subscriptionId")
+
+        when:
+        hermesService.subscribe(authorEmail, subscription)
+
+        then:
+        1 * hermesClient.subscribe(authorEmail, request) >> response
+
+    }
+
+    def 'when getting a subscription, should do it successfully'() {
+
+        when:
+        hermesService.getSubscription(authorEmail, "subscriptionId")
+
+        then:
+        1 * hermesClient.getSubscription(authorEmail, "subscriptionId") >> hermesSubscriptionResponse
+
+    }
+
+    def 'when update a subscription, should do it successfully'() {
+        given:
+        def request = new HermesSubscriptionUpdateRequest(events)
+
+        when:
+        hermesService.updateSubscription(authorEmail, "subscriptionId", events)
+
+        then:
+        1 * hermesClient.updateSubscription(authorEmail, "subscriptionId", request) >> hermesSubscriptionResponse
+
+    }
+
+    def 'when delete a subscription, should do it successfully'() {
+
+        when:
+        hermesService.deleteSubscription(authorEmail, "subscriptionId")
+
+        then:
+        1 * hermesClient.deleteSubscription(authorEmail, "subscriptionId")
+
+    }
+
+    private static String getAuthorEmail() {
+        return "email@email.com"
+    }
+
+    private static HermesSubscriptionResponse getHermesSubscriptionResponse() {
+        return new HermesSubscriptionResponse('https://mywebhook.com.br', 'secret', 'workspaceId',
+                'My Webhook', events)
+    }
+
+    private static List<String> getEvents() {
+        def events = new ArrayList()
+        events.add("DEPLOY")
+        return events
+    }
+}

--- a/moove/web/src/main/resources/application-k8s.properties
+++ b/moove/web/src/main/resources/application-k8s.properties
@@ -12,10 +12,9 @@ charlescd.compass.url=http://charlescd-compass:8080
 charlescd.villager.url=http://charlescd-villager:8080
 charlescd.deploy.url=http://charlescd-butler:3000
 charlescd.moove.url=http://charlescd-moove:8080
-charlescd.notification.url=http://charlescd-notifications:8080
 charlescd.notification.path=/notifications
 prometheus.url=http://prometheus
-
+charlescd.hermes.url=http://charlescd-hermes:8080
 charlescd.matcher.url=http://charlescd-circle-matcher:8080
 charlescd.matcher.path=/segmentation
 

--- a/moove/web/src/main/resources/application-k8s.properties
+++ b/moove/web/src/main/resources/application-k8s.properties
@@ -12,6 +12,7 @@ charlescd.compass.url=http://charlescd-compass:8080
 charlescd.villager.url=http://charlescd-villager:8080
 charlescd.deploy.url=http://charlescd-butler:3000
 charlescd.moove.url=http://charlescd-moove:8080
+charlescd.notification.url=http://charlescd-notifications:8080
 charlescd.notification.path=/notifications
 prometheus.url=http://prometheus
 charlescd.hermes.url=http://charlescd-hermes:8080

--- a/moove/web/src/main/resources/application-local.properties
+++ b/moove/web/src/main/resources/application-local.properties
@@ -16,6 +16,7 @@ charlescd.matcher.url=http://localhost:8883
 charlescd.matcher.path=/segmentation
 prometheus.url=http://localhost:9090
 charlescd.compass.url=http://localhost:8090
+charlescd.hermes.url=http://localhost:8883
 
 charlescd.keycloak.realm=charlescd
 charlescd.keycloak.serverUrl=https://charlescd-moove.com/auth

--- a/moove/web/src/main/resources/security-constraints.yml
+++ b/moove/web/src/main/resources/security-constraints.yml
@@ -204,6 +204,14 @@ constraints:
       maintenance_write:
         - GET
 
+  - pattern: /v1/webhooks/**
+    roles:
+      maintenance_write:
+        - GET
+        - POST
+        - PATCH
+        - DELETE
+
 managementConstraints:
   - pattern: /v2/users/{email:.+}
     methods:


### PR DESCRIPTION

**What is:** 
Expose CRUD APIs from webhook feature in moove and integration with Hermes APIS

- POST /v1/webhooks

- GET /v1/webhooks/{id}

- PATCH /v1/webhooks/{id}

- DELETE /v1/webhooks/{id}


**Signed-off-by:** barbararochazup <barbara.rocha@zup.com.br>


