### PR TITLE
Datasource test connection error

### DIFF
--- a/compass/web/api/v1/datasource/datasource.go
+++ b/compass/web/api/v1/datasource/datasource.go
@@ -63,7 +63,7 @@ func TestConnection(datasourceMain datasource.UseCases) func(w http.ResponseWrit
 		}
 
 		testConnErr := datasourceMain.TestConnection(newTestConnection.PluginSrc, newTestConnection.Data)
-		if err != nil {
+		if testConnErr != nil {
 			util.NewResponse(w, http.StatusInternalServerError, testConnErr)
 			return
 		}


### PR DESCRIPTION
Fixing a bug that causes datasource's test connection to always return true, even if the connection is not working