### PR TITLE
Update graalvm image

### DIFF
--- a/circle-matcher/Dockerfile
+++ b/circle-matcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM oracle/graalvm-ce:20.3.0-java11
+FROM findepi/graalvm:20.3.0-java11
 
 ENV APP_TARGET target
 ENV APP charlescd-circle-matcher.jar


### PR DESCRIPTION
Image graalvm oracle was removed from docker up.

Update docker file to use a new image.