### PR TITLE
User Group modal multi-selection lost the selection after a search

### DIFF
--- a/ui/src/modules/Groups/Tabs/Modal/index.tsx
+++ b/ui/src/modules/Groups/Tabs/Modal/index.tsx
@@ -139,6 +139,8 @@ const AddUserModal = ({
     return <UserItem key={user.id} {...user} onSelected={setSelected} />
   }
 
+  const renderItems = () => map(users, user => renderItem(user))
+  
   return (
     <Styled.Wrapper
       data-testid="modal-user"
@@ -160,8 +162,7 @@ const AddUserModal = ({
             />
           </Styled.Header>
           <Styled.Content ref={contentRef}>
-            {map(users, user => renderItem(user))}
-            {isEmpty(users) && renderPlaceHolder()}
+            {isEmpty(users) ? renderPlaceHolder() : renderItems()}
           </Styled.Content>
           <Styled.Button.Update>
             <Button.Default

--- a/ui/src/modules/Groups/Tabs/Modal/index.tsx
+++ b/ui/src/modules/Groups/Tabs/Modal/index.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import map from 'lodash/map';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
+import find from 'lodash/find';
 import xorBy from 'lodash/xorBy';
 import { User } from 'modules/Users/interfaces/User';
 import { UserChecked } from '../../interfaces/UserChecked';
@@ -71,7 +72,7 @@ const UserItem = ({ id, name, email, checked, onSelected }: UserItemProps) => {
   };
 
   return (
-    <Styled.Item.Wrapper onClick={() => handleSelected(id)}>
+    <Styled.Item.Wrapper key={`user-item-${id}`} onClick={() => handleSelected(id)}>
       <Styled.Item.Profile>
         <Styled.Item.Photo name={name} />
         <div>
@@ -107,7 +108,9 @@ const AddUserModal = ({
     }
   });
 
-  useOutsideClick(contentRef, () => setIsDisabled(true));
+  useEffect(() => {
+    setIsDisabled(isEmpty(changedUsers));
+  }, [changedUsers])
 
   const setSelected = (id: string, checked: boolean) => {
     if (!isEmpty(id)) {
@@ -125,6 +128,16 @@ const AddUserModal = ({
       </Text.h4>
     </Styled.Placeholder>
   );
+
+  const renderItem = (user: UserChecked) => {
+    const userChanged = find(changedUsers, { id: user.id });
+
+    if (userChanged) {
+      user.checked = userChanged.checked
+    };
+
+    return <UserItem key={user.id} {...user} onSelected={setSelected} />
+  }
 
   return (
     <Styled.Wrapper
@@ -147,9 +160,7 @@ const AddUserModal = ({
             />
           </Styled.Header>
           <Styled.Content ref={contentRef}>
-            {map(users, user => (
-              <UserItem key={user.id} {...user} onSelected={setSelected} />
-            ))}
+            {map(users, user => renderItem(user))}
             {isEmpty(users) && renderPlaceHolder()}
           </Styled.Content>
           <Styled.Button.Update>

--- a/ui/src/modules/Groups/Tabs/Modal/styled.ts
+++ b/ui/src/modules/Groups/Tabs/Modal/styled.ts
@@ -155,7 +155,6 @@ const UpdateButtonWrapper = styled.div`
   align-items: center;
   padding: 20px 50px;
   border-bottom: 1px solid ${COLOR_BLACK_MARLIN};
-  cursor: pointer;
 `;
 
 const ItemChecked = styled.div``;


### PR DESCRIPTION
Resolution
---
- Listen the list of changed users before re-render the items.
- Remove `cursor: pointer` to avoid incorrect click outside the Update Button.