### PR TITLE
Butler operator health status

### DIFF
--- a/butler/src/app/v2/api/deployments/repository/component.repository.ts
+++ b/butler/src/app/v2/api/deployments/repository/component.repository.ts
@@ -31,6 +31,17 @@ export class ComponentsRepositoryV2 extends Repository<ComponentEntityV2> {
       .getMany()
   }
 
+  public async findHealthyActiveComponents(cdConfigurationId: string): Promise<ComponentEntityV2[]> {
+    // WARNING: ALWAYS RETURN COMPONENT WITH ITS DEPLOYMENT
+    return this.createQueryBuilder('v2components')
+      .leftJoinAndSelect('v2components.deployment', 'deployment')
+      .where('deployment.current = true')
+      .andWhere('deployment.healthy = true')
+      .andWhere('deployment.cd_configuration_id = :cdConfigurationId', { cdConfigurationId })
+      .orderBy('deployment.created_at', 'DESC')
+      .getMany()
+  }
+
   public async findDefaultActiveComponents(defaultCircleId: string): Promise<ComponentEntityV2[]> {
     // WARNING: ALWAYS RETURN COMPONENT WITH ITS DEPLOYMENT
     return this.createQueryBuilder('v2components')

--- a/butler/src/app/v2/api/deployments/repository/deployment.repository.ts
+++ b/butler/src/app/v2/api/deployments/repository/deployment.repository.ts
@@ -36,11 +36,12 @@ export class DeploymentRepositoryV2 extends Repository<DeploymentEntityV2> {
       .execute()
     return this.findOneOrFail(updated.raw[0].id)
   }
-  public async updateRouteStatus(id: string, status: boolean): Promise<DeploymentEntityV2> {
+
+  public async updateRouteStatus(circleId: string, status: boolean): Promise<DeploymentEntityV2> {
     const updated = await this.createQueryBuilder('d')
       .update()
       .set({ routed: status })
-      .where({ id: id })
+      .where({ circleId: circleId, current: true })
       .returning('id')
       .execute()
     return this.findOneOrFail(updated.raw[0].id)

--- a/butler/src/app/v2/api/deployments/repository/deployment.repository.ts
+++ b/butler/src/app/v2/api/deployments/repository/deployment.repository.ts
@@ -34,7 +34,7 @@ export class DeploymentRepositoryV2 extends Repository<DeploymentEntityV2> {
       .where({ id: id })
       .returning('id')
       .execute()
-    return this.findOneOrFail(updated.raw[0].id)
+    return await this.findOneOrFail(updated.raw[0].id)
   }
 
   public async updateRouteStatus(circleId: string, status: boolean): Promise<DeploymentEntityV2> {
@@ -44,7 +44,7 @@ export class DeploymentRepositoryV2 extends Repository<DeploymentEntityV2> {
       .where({ circleId: circleId, current: true })
       .returning('id')
       .execute()
-    return this.findOneOrFail(updated.raw[0].id)
+    return await this.findOneOrFail(updated.raw[0].id)
   }
 
   public async findWithComponentsAndConfig(deploymentId: string): Promise<DeploymentEntityV2> {

--- a/butler/src/app/v2/api/deployments/use-cases/create-undeployment.usecase.ts
+++ b/butler/src/app/v2/api/deployments/use-cases/create-undeployment.usecase.ts
@@ -54,7 +54,7 @@ export class CreateUndeploymentUseCase {
   private async createExecution(deployment: DeploymentEntity, incomingCircleId: string | null): Promise<Execution> {
     this.consoleLoggerService.log('START:CREATE_UNDEPLOYMENT_EXECUTION', { deployment: deployment.id })
     const execution = await this.executionRepository.save({ deployment, type: ExecutionTypeEnum.UNDEPLOYMENT, incomingCircleId })
-    await this.deploymentsRepository.update({ id: deployment.id }, { current: false })
+    await this.deploymentsRepository.update({ id: deployment.id }, { current: false, healthy: false, routed: false })
     this.consoleLoggerService.log('FINISH:CREATE_UNDEPLOYMENT_EXECUTION', { execution: execution.id })
     return execution
   }

--- a/butler/src/app/v2/core/integrations/utils/istio-deployment-manifests.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/istio-deployment-manifests.utils.ts
@@ -30,7 +30,8 @@ const IstioDeploymentManifestsUtils = {
       kind: 'VirtualService',
       metadata: {
         name: `${component.name}`,
-        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`
+        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
+        circles: activeByName.map(c => c.deployment.circleId)
       },
       spec: {
         gateways: component.gatewayName ? [component.gatewayName] : [],
@@ -48,7 +49,8 @@ const IstioDeploymentManifestsUtils = {
       kind: 'DestinationRule',
       metadata: {
         name: component.name,
-        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`
+        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
+        circles: activeByName.map(c => c.deployment.circleId)
       },
       spec: {
         host: component.name,

--- a/butler/src/app/v2/core/integrations/utils/istio-deployment-manifests.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/istio-deployment-manifests.utils.ts
@@ -20,10 +20,11 @@ import { Component, Deployment } from '../../../api/deployments/interfaces'
 import { IstioManifestsUtils } from './istio-manifests.utilts'
 import { DeploymentUtils } from './deployment.utils'
 import { DeploymentComponent } from '../../../api/deployments/interfaces/deployment.interface'
+import { DestinationRuleSpec, VirtualServiceSpec } from '../../../operator/params.interface'
 
 const IstioDeploymentManifestsUtils = {
 
-  getVirtualServiceManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): K8sManifest => {
+  getVirtualServiceManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): VirtualServiceSpec => {
     return {
       apiVersion: 'networking.istio.io/v1beta1',
       kind: 'VirtualService',
@@ -41,7 +42,7 @@ const IstioDeploymentManifestsUtils = {
     }
   },
 
-  getDestinationRulesManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): K8sManifest => {
+  getDestinationRulesManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): DestinationRuleSpec => {
     return {
       apiVersion: 'networking.istio.io/v1beta1',
       kind: 'DestinationRule',

--- a/butler/src/app/v2/core/integrations/utils/istio-deployment-manifests.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/istio-deployment-manifests.utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Http, K8sManifest, Subset } from '../interfaces/k8s-manifest.interface'
+import { Http, Subset } from '../interfaces/k8s-manifest.interface'
 import { ISpinnakerConfigurationData } from '../../../api/configurations/interfaces'
 import { Component, Deployment } from '../../../api/deployments/interfaces'
 import { IstioManifestsUtils } from './istio-manifests.utilts'
@@ -31,7 +31,9 @@ const IstioDeploymentManifestsUtils = {
       metadata: {
         name: `${component.name}`,
         namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
-        circles: activeByName.map(c => c.deployment.circleId)
+        annotations: {
+          circles: JSON.stringify(activeByName.map(c => c.deployment.circleId))
+        }
       },
       spec: {
         gateways: component.gatewayName ? [component.gatewayName] : [],
@@ -50,7 +52,9 @@ const IstioDeploymentManifestsUtils = {
       metadata: {
         name: component.name,
         namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
-        circles: activeByName.map(c => c.deployment.circleId)
+        annotations: {
+          circles: JSON.stringify(activeByName.map(c => c.deployment.circleId))
+        }
       },
       spec: {
         host: component.name,

--- a/butler/src/app/v2/core/integrations/utils/istio-undeployment-manifests.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/istio-undeployment-manifests.utils.ts
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-import { Http, K8sManifest, Subset } from '../interfaces/k8s-manifest.interface'
-import { Component, Deployment } from '../../../api/deployments/interfaces'
 import { ISpinnakerConfigurationData } from '../../../api/configurations/interfaces'
-import { IstioManifestsUtils } from './istio-manifests.utilts'
-import { DeploymentUtils } from './deployment.utils'
+import { Component, Deployment } from '../../../api/deployments/interfaces'
 import { DeploymentComponent } from '../../../api/deployments/interfaces/deployment.interface'
+import { DestinationRuleSpec, VirtualServiceSpec } from '../../../operator/params.interface'
+import { Http, Subset } from '../interfaces/k8s-manifest.interface'
+import { DeploymentUtils } from './deployment.utils'
+import { IstioManifestsUtils } from './istio-manifests.utilts'
 
 const IstioUndeploymentManifestsUtils = {
 
-  getVirtualServiceManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): K8sManifest => {
+  getVirtualServiceManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): VirtualServiceSpec => {
     return {
       apiVersion: 'networking.istio.io/v1beta1',
       kind: 'VirtualService',
       metadata: {
         name: `${component.name}`,
-        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`
+        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
+        circles: activeByName.map(c => c.deployment.circleId)
       },
       spec: {
         gateways: component.gatewayName ? [component.gatewayName] : [],
@@ -39,13 +41,14 @@ const IstioUndeploymentManifestsUtils = {
     }
   },
 
-  getEmptyVirtualServiceManifest: (deployment: Deployment, component: DeploymentComponent): K8sManifest => {
+  getEmptyVirtualServiceManifest: (deployment: Deployment, component: DeploymentComponent): VirtualServiceSpec => {
     return {
       apiVersion: 'networking.istio.io/v1beta1',
       kind: 'VirtualService',
       metadata: {
         name: component.name,
-        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`
+        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
+        circles: []
       },
       spec: {
         gateways: component.gatewayName ? [component.gatewayName] : [],
@@ -74,17 +77,19 @@ const IstioUndeploymentManifestsUtils = {
     }
   },
 
-  getDestinationRulesManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): K8sManifest => {
+  getDestinationRulesManifest: (deployment: Deployment, component: DeploymentComponent, activeByName: Component[]): DestinationRuleSpec => {
+    const istioSubsets = IstioUndeploymentManifestsUtils.getActiveComponentsSubsets(deployment.circleId, activeByName)
     return {
       apiVersion: 'networking.istio.io/v1beta1',
       kind: 'DestinationRule',
       metadata: {
         name: component.name,
-        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`
+        namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
+        circles: istioSubsets.map(s => s.labels.circleId)
       },
       spec: {
         host: component.name,
-        subsets: IstioUndeploymentManifestsUtils.getActiveComponentsSubsets(deployment.circleId, activeByName)
+        subsets: istioSubsets
       }
     }
   },

--- a/butler/src/app/v2/core/integrations/utils/istio-undeployment-manifests.utils.ts
+++ b/butler/src/app/v2/core/integrations/utils/istio-undeployment-manifests.utils.ts
@@ -31,7 +31,9 @@ const IstioUndeploymentManifestsUtils = {
       metadata: {
         name: `${component.name}`,
         namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
-        circles: activeByName.map(c => c.deployment.circleId)
+        annotations: {
+          circles: JSON.stringify(activeByName.map(c => c.deployment.circleId))
+        }
       },
       spec: {
         gateways: component.gatewayName ? [component.gatewayName] : [],
@@ -48,7 +50,10 @@ const IstioUndeploymentManifestsUtils = {
       metadata: {
         name: component.name,
         namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
-        circles: []
+        annotations: {
+          circles: JSON.stringify([])
+        }
+
       },
       spec: {
         gateways: component.gatewayName ? [component.gatewayName] : [],
@@ -85,7 +90,9 @@ const IstioUndeploymentManifestsUtils = {
       metadata: {
         name: component.name,
         namespace: `${(deployment.cdConfiguration.configurationData as ISpinnakerConfigurationData).namespace}`,
-        circles: istioSubsets.map(s => s.labels.circleId)
+        annotations: {
+          circles: JSON.stringify(istioSubsets.map(s => s.labels.circleId))
+        }
       },
       spec: {
         host: component.name,

--- a/butler/src/app/v2/operator/deployments.hook.controller.ts
+++ b/butler/src/app/v2/operator/deployments.hook.controller.ts
@@ -7,7 +7,7 @@ import { KubernetesManifest } from '../core/integrations/interfaces/k8s-manifest
 import { K8sClient } from '../core/integrations/k8s/client'
 import { ConsoleLoggerService } from '../core/logs/console/console-logger.service'
 import { HookParams } from './params.interface'
-import { Reconcile } from './reconcile'
+import { ReconcileDeployment } from './use-cases/reconcile-deployments.usecase'
 
 @Controller('/')
 export class DeploymentsHookController {
@@ -17,25 +17,25 @@ export class DeploymentsHookController {
     private readonly deploymentRepository: DeploymentRepositoryV2,
     private readonly componentRepository: ComponentsRepositoryV2,
     private readonly configurationRepository: CdConfigurationsRepository,
-    private readonly consoleLoggerService: ConsoleLoggerService
+    private readonly consoleLoggerService: ConsoleLoggerService,
+    private readonly reconcileUseCase: ReconcileDeployment
   ) { }
 
   @Post('/v2/operator/deployment/hook/reconcile')
   @HttpCode(200)
   @UsePipes(new ValidationPipe({ transform: true }))
   public async reconcile(@Body() params: HookParams) : Promise<{status?: unknown, children: KubernetesManifest[], resyncAfterSeconds?: number}> {
-    const reconcile = new Reconcile()
     const deployment = await this.deploymentRepository.findWithComponentsAndConfig(params.parent.spec.deploymentId)
     const decryptedConfig = await this.configurationRepository.findDecrypted(deployment.cdConfiguration.id)
     const rawSpecs = deployment.components.flatMap(c => c.manifests)
-    const specs = reconcile.addMetadata(rawSpecs, deployment)
+    const specs = this.reconcileUseCase.addMetadata(rawSpecs, deployment)
 
     if (isEmpty(params.children['Deployment.apps/v1'])) {
       return { children: specs, resyncAfterSeconds: 5 }
     }
-    const currentDeploymentSpecs = reconcile.specsByDeployment(params, deployment.id)
+    const currentDeploymentSpecs = this.reconcileUseCase.specsByDeployment(params, deployment.id)
 
-    const allReady = reconcile.checkConditions(currentDeploymentSpecs)
+    const allReady = this.reconcileUseCase.checkConditions(currentDeploymentSpecs)
     if (allReady === false) {
       const previousDeploymentId = deployment.previousDeploymentId
 
@@ -44,7 +44,7 @@ export class DeploymentsHookController {
         return { children: specs, resyncAfterSeconds: 5 }
       }
       const previousDeployment = await this.deploymentRepository.findWithComponentsAndConfig(previousDeploymentId)
-      const currentAndPrevious = reconcile.concatWithPrevious(previousDeployment, specs)
+      const currentAndPrevious = this.reconcileUseCase.concatWithPrevious(previousDeployment, specs)
       return { children: currentAndPrevious, resyncAfterSeconds: 5 }
     }
 

--- a/butler/src/app/v2/operator/params.interface.ts
+++ b/butler/src/app/v2/operator/params.interface.ts
@@ -103,7 +103,9 @@ export interface VirtualServiceSpec {
     metadata: {
       name: string
       namespace: string
-      circles: string[]
+      annotations: {
+        circles: string,
+      }
     }
     spec: {
       gateways: string[]
@@ -118,7 +120,10 @@ export interface DestinationRuleSpec {
     metadata: {
       name: string
       namespace: string
-      circles: string[]
+      annotations: {
+        circles: string,
+      }
+      teste?: string
     }
     spec: {
       host: string

--- a/butler/src/app/v2/operator/params.interface.ts
+++ b/butler/src/app/v2/operator/params.interface.ts
@@ -1,3 +1,5 @@
+import { Http } from '../core/integrations/interfaces/k8s-manifest.interface'
+
 export interface RouteHookParams {
   controller?: Record<string, unknown>
   parent: {
@@ -20,8 +22,8 @@ export interface RouteHookParams {
 }
 
 export interface RouteChildren {
-  'VirtualService.networking.istio.io/v1beta1': VirtualServiceSpec,
-  'DestinationRule.networking.istio.io/v1beta1': DestinationRuleSpec
+  'VirtualService.networking.istio.io/v1beta1': ChildVirtualServiceSpec,
+  'DestinationRule.networking.istio.io/v1beta1': ChildDestinationRuleSpec
 }
 
 export interface HookParams {
@@ -87,53 +89,35 @@ export interface DeploymentSpec {
   }
 }
 
+export interface ChildVirtualServiceSpec {
+  [key: string]: VirtualServiceSpec
+}
+
 export interface VirtualServiceSpec {
-  [key: string]: {
     apiVersion: string
-    kind: string
-    metadata?: SpecMetadata
+    kind: 'VirtualService'
+    metadata: {
+      name: string
+      namespace: string
+    }
     spec: {
       gateways: string[]
       hosts: string[]
-      http: {
-        match?: {
-          headers: {
-            cookie?: {
-              regex: string
-            }
-            'x-circle-id'?: {
-              exact: string
-            }
-          }
-        }[],
-        route: {
-          destination: {
-            host: string
-            subset: string
-          }
-          headers: {
-            request: {
-              set: {
-                'x-circle-source': string
-              }
-            },
-            response: {
-              set: {
-                'x-circle-source': string
-              }
-            }
-          }
-        }[]
-      }[]
+      http: Http[]
     }
   }
+
+export interface ChildDestinationRuleSpec {
+  [key: string]: DestinationRuleSpec
 }
 
 export interface DestinationRuleSpec {
-  [key: string]: {
     apiVersion: string
-    kind: string
-    metadata?: SpecMetadata
+    kind: 'DestinationRule'
+    metadata: {
+      name: string
+      namespace: string
+    }
     spec: {
       host: string
       subsets: {
@@ -146,7 +130,6 @@ export interface DestinationRuleSpec {
       }[]
     }
   }
-}
 
 export interface ServiceSpec {
   [key: string]: {

--- a/butler/src/app/v2/operator/params.interface.ts
+++ b/butler/src/app/v2/operator/params.interface.ts
@@ -93,12 +93,17 @@ export interface ChildVirtualServiceSpec {
   [key: string]: VirtualServiceSpec
 }
 
+export interface ChildDestinationRuleSpec {
+  [key: string]: DestinationRuleSpec
+}
+
 export interface VirtualServiceSpec {
     apiVersion: string
     kind: 'VirtualService'
     metadata: {
       name: string
       namespace: string
+      circles: string[]
     }
     spec: {
       gateways: string[]
@@ -107,16 +112,13 @@ export interface VirtualServiceSpec {
     }
   }
 
-export interface ChildDestinationRuleSpec {
-  [key: string]: DestinationRuleSpec
-}
-
 export interface DestinationRuleSpec {
     apiVersion: string
     kind: 'DestinationRule'
     metadata: {
       name: string
       namespace: string
+      circles: string[]
     }
     spec: {
       host: string

--- a/butler/src/app/v2/operator/partial-params.interface.ts
+++ b/butler/src/app/v2/operator/partial-params.interface.ts
@@ -1,0 +1,36 @@
+import { VirtualServiceSpec, DestinationRuleSpec } from './params.interface'
+
+type PartialVirtualServiceSpec = Pick<VirtualServiceSpec, 'kind' | 'metadata'>
+type PartialDestinationRuleSpec = Pick<DestinationRuleSpec, 'kind' | 'metadata'>
+export type SpecsUnion = PartialVirtualServiceSpec | PartialDestinationRuleSpec
+
+
+export interface PartialRouteHookParams {
+  parent: {
+    spec: {
+      circles: {
+        components: {
+          name: string
+          tag: string
+        }[]
+        default: boolean
+        id: string
+      }[]
+    }
+  }
+  children: PartialRouteChildren
+}
+
+interface PartialRouteChildren {
+  'VirtualService.networking.istio.io/v1beta1': PartialChildVirtualServiceSpec,
+  'DestinationRule.networking.istio.io/v1beta1': PartialChildDestinationRuleSpec
+}
+
+
+interface PartialChildVirtualServiceSpec {
+  [key: string]: PartialVirtualServiceSpec
+}
+
+interface PartialChildDestinationRuleSpec {
+  [key: string]: PartialDestinationRuleSpec
+}

--- a/butler/src/app/v2/operator/use-cases/create-routes-manifests.usecase.ts
+++ b/butler/src/app/v2/operator/use-cases/create-routes-manifests.usecase.ts
@@ -48,7 +48,7 @@ export class CreateRoutesManifestsUseCase {
       specs = specs.concat(proxySpecs)
     }
     const healthStatus = this.getRoutesStatus(hookParams, specs)
-    await this.updateHealthStatus(healthStatus)
+    await this.updateRouteStatus(healthStatus)
     return { children: specs, resyncAfterSeconds: 5 }
   }
 
@@ -64,7 +64,7 @@ export class CreateRoutesManifestsUseCase {
     })
   }
 
-  public async updateHealthStatus(componentStatus: { circle: string, component: string, status: boolean, kind: string }[]): Promise<DeploymentEntityV2[]>  {
+  public async updateRouteStatus(componentStatus: { circle: string, component: string, status: boolean, kind: string }[]): Promise<DeploymentEntityV2[]>  {
     const components = groupBy(componentStatus, 'circle')
     const results =  await Promise.all(Object.entries(components).flatMap(async c => {
       const circleId = c[0]

--- a/butler/src/app/v2/operator/use-cases/reconcile-deployments.usecase.ts
+++ b/butler/src/app/v2/operator/use-cases/reconcile-deployments.usecase.ts
@@ -1,10 +1,11 @@
+import { Injectable } from '@nestjs/common'
 import { uniqWith } from 'lodash'
-import { DeploymentEntityV2 } from '../api/deployments/entity/deployment.entity'
-import { KubernetesManifest } from '../core/integrations/interfaces/k8s-manifest.interface'
-import { HookParams, SpecMetadata, SpecStatus } from './params.interface'
+import { DeploymentEntityV2 } from '../../api/deployments/entity/deployment.entity'
+import { KubernetesManifest } from '../../core/integrations/interfaces/k8s-manifest.interface'
+import { HookParams, SpecMetadata, SpecStatus } from '../params.interface'
 
-
-export class Reconcile {
+@Injectable()
+export class ReconcileDeployment {
   public concatWithPrevious(previousDeployment: DeploymentEntityV2, specs: KubernetesManifest[]) : KubernetesManifest[] {
     const rawSpecs = previousDeployment.components.flatMap(c => c.manifests)
     const previousSpecs = this.addMetadata(rawSpecs, previousDeployment)

--- a/butler/src/tests/v2/fixtures/manifests.fixture.ts
+++ b/butler/src/tests/v2/fixtures/manifests.fixture.ts
@@ -57,7 +57,9 @@ export const routesManifests: KubernetesManifest[] = [
     metadata: {
       name: 'hello-kubernetes',
       namespace: 'namespace',
-      circles: ['b46fd548-0082-4021-ba80-a50703c44a3b']
+      annotations: {
+        circles: '["b46fd548-0082-4021-ba80-a50703c44a3b"]'
+      }
     },
     spec: {
       host: 'hello-kubernetes',
@@ -79,7 +81,9 @@ export const routesManifests: KubernetesManifest[] = [
     metadata: {
       name: 'hello-kubernetes',
       namespace: 'namespace',
-      circles: ['b46fd548-0082-4021-ba80-a50703c44a3b']
+      annotations: {
+        circles: '["b46fd548-0082-4021-ba80-a50703c44a3b"]'
+      }
     },
     spec: {
       gateways: [

--- a/butler/src/tests/v2/fixtures/manifests.fixture.ts
+++ b/butler/src/tests/v2/fixtures/manifests.fixture.ts
@@ -57,6 +57,7 @@ export const routesManifests: KubernetesManifest[] = [
     metadata: {
       name: 'hello-kubernetes',
       namespace: 'namespace',
+      circles: ['b46fd548-0082-4021-ba80-a50703c44a3b']
     },
     spec: {
       host: 'hello-kubernetes',
@@ -78,6 +79,7 @@ export const routesManifests: KubernetesManifest[] = [
     metadata: {
       name: 'hello-kubernetes',
       namespace: 'namespace',
+      circles: ['b46fd548-0082-4021-ba80-a50703c44a3b']
     },
     spec: {
       gateways: [

--- a/butler/src/tests/v2/integration/operator/create-routes-manifests-usecase.integration-spec.ts
+++ b/butler/src/tests/v2/integration/operator/create-routes-manifests-usecase.integration-spec.ts
@@ -1,0 +1,182 @@
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { EntityManager } from 'typeorm'
+import { AppModule } from '../../../../app/app.module'
+import { DeploymentRepositoryV2 } from '../../../../app/v2/api/deployments/repository/deployment.repository'
+import { CreateRoutesManifestsUseCase } from '../../../../app/v2/operator/use-cases/create-routes-manifests.usecase'
+import { cdConfigurationFixture, deploymentFixture } from '../../fixtures/deployment-entity.fixture'
+import { FixtureUtilsService } from '../fixture-utils.service'
+import { TestSetupUtils } from '../test-setup-utils'
+
+describe('Routes manifest use case', () => {
+  let fixtureUtilsService: FixtureUtilsService
+  let app: INestApplication
+  let repo: DeploymentRepositoryV2
+  let routeUseCase: CreateRoutesManifestsUseCase
+  let manager: EntityManager
+
+  beforeAll(async() => {
+    const module = Test.createTestingModule({
+      imports: [
+        await AppModule.forRootAsync()
+      ],
+      providers: [
+        FixtureUtilsService,
+        DeploymentRepositoryV2
+      ]
+    })
+
+    app = await TestSetupUtils.createApplication(module)
+    TestSetupUtils.seApplicationConstants()
+    fixtureUtilsService = app.get<FixtureUtilsService>(FixtureUtilsService)
+    repo = app.get<DeploymentRepositoryV2>(DeploymentRepositoryV2)
+    routeUseCase = app.get<CreateRoutesManifestsUseCase>(CreateRoutesManifestsUseCase)
+    manager = fixtureUtilsService.connection.manager
+  })
+
+  afterAll(async() => {
+    await fixtureUtilsService.clearDatabase()
+    await app.close()
+  })
+
+  beforeEach(async() => {
+    await fixtureUtilsService.clearDatabase()
+  })
+
+  it('Updates the healthy column to true when both VirtualService and DestinationRule for a component is true', async() => {
+    const configuration = await manager.save(cdConfigurationFixture)
+    deploymentFixture.cdConfiguration = configuration
+    deploymentFixture.circleId = 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60'
+    await repo.save(deploymentFixture)
+
+    const params = [
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'jilo',
+        kind: 'DestinationRule',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'jilo',
+        kind: 'VirtualService',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'DestinationRule',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'VirtualService',
+        status: true
+      }
+    ]
+
+    const result = await routeUseCase.updateHealthStatus(params)
+    expect(result.map(r => r.routed)).toEqual([true])
+  })
+
+  it('Updates the healthy column to false when at least one manifest status is false', async() => {
+    const configuration = await manager.save(cdConfigurationFixture)
+    deploymentFixture.cdConfiguration = configuration
+    deploymentFixture.circleId = 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60'
+    await repo.save(deploymentFixture)
+
+    const params = [
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'jilo',
+        kind: 'DestinationRule',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'jilo',
+        kind: 'VirtualService',
+        status: false
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'DestinationRule',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'VirtualService',
+        status: true
+      }
+    ]
+
+    const result = await routeUseCase.updateHealthStatus(params)
+    expect(result.map(r => r.routed)).toEqual([false])
+  })
+
+  it('Updates the healthy column for multiple circles independently', async() => {
+    const configuration = await manager.save(cdConfigurationFixture)
+    const firstCircleId = 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60'
+    const secondCircleId = 'ed2a1669-34b8-4af2-b42c-acbad2ec6b60'
+    const firstDeployment = deploymentFixture
+    const secondDeployment = deploymentFixture
+    firstDeployment.cdConfiguration = configuration
+    firstDeployment.circleId = firstCircleId
+    await repo.save(firstDeployment)
+
+    secondDeployment.cdConfiguration = configuration
+    secondDeployment.circleId = secondCircleId
+    secondDeployment.id = 'a7d08a07-f29d-452e-a667-7a39820f3262'
+    await repo.save(secondDeployment)
+
+    const params = [
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'jilo',
+        kind: 'DestinationRule',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'jilo',
+        kind: 'VirtualService',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'DestinationRule',
+        status: true
+      },
+      {
+        circle: 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'VirtualService',
+        status: true
+      },
+      {
+        circle: 'ed2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'DestinationRule',
+        status: false
+      },
+      {
+        circle: 'ed2a1669-34b8-4af2-b42c-acbad2ec6b60',
+        component: 'abobora',
+        kind: 'VirtualService',
+        status: true
+      }
+    ]
+
+    const result = await routeUseCase.updateHealthStatus(params)
+    expect(result.map(r => ({ circle: r.circleId, routed: r.routed }))).toEqual(
+      [
+        { circle: firstCircleId, routed: true },
+        { circle: secondCircleId, routed: false }
+      ]
+    )
+  })
+})

--- a/butler/src/tests/v2/integration/operator/create-routes-manifests-usecase.integration-spec.ts
+++ b/butler/src/tests/v2/integration/operator/create-routes-manifests-usecase.integration-spec.ts
@@ -11,7 +11,7 @@ import { TestSetupUtils } from '../test-setup-utils'
 describe('Routes manifest use case', () => {
   let fixtureUtilsService: FixtureUtilsService
   let app: INestApplication
-  let repo: DeploymentRepositoryV2
+  let deploymentRepository: DeploymentRepositoryV2
   let routeUseCase: CreateRoutesManifestsUseCase
   let manager: EntityManager
 
@@ -29,7 +29,7 @@ describe('Routes manifest use case', () => {
     app = await TestSetupUtils.createApplication(module)
     TestSetupUtils.seApplicationConstants()
     fixtureUtilsService = app.get<FixtureUtilsService>(FixtureUtilsService)
-    repo = app.get<DeploymentRepositoryV2>(DeploymentRepositoryV2)
+    deploymentRepository = app.get<DeploymentRepositoryV2>(DeploymentRepositoryV2)
     routeUseCase = app.get<CreateRoutesManifestsUseCase>(CreateRoutesManifestsUseCase)
     manager = fixtureUtilsService.connection.manager
   })
@@ -47,7 +47,8 @@ describe('Routes manifest use case', () => {
     const configuration = await manager.save(cdConfigurationFixture)
     deploymentFixture.cdConfiguration = configuration
     deploymentFixture.circleId = 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60'
-    await repo.save(deploymentFixture)
+    deploymentFixture.current = true
+    await deploymentRepository.save(deploymentFixture)
 
     const params = [
       {
@@ -76,7 +77,7 @@ describe('Routes manifest use case', () => {
       }
     ]
 
-    const result = await routeUseCase.updateHealthStatus(params)
+    const result = await routeUseCase.updateRouteStatus(params)
     expect(result.map(r => r.routed)).toEqual([true])
   })
 
@@ -84,7 +85,8 @@ describe('Routes manifest use case', () => {
     const configuration = await manager.save(cdConfigurationFixture)
     deploymentFixture.cdConfiguration = configuration
     deploymentFixture.circleId = 'ad2a1669-34b8-4af2-b42c-acbad2ec6b60'
-    await repo.save(deploymentFixture)
+    deploymentFixture.current = true
+    await deploymentRepository.save(deploymentFixture)
 
     const params = [
       {
@@ -113,7 +115,7 @@ describe('Routes manifest use case', () => {
       }
     ]
 
-    const result = await routeUseCase.updateHealthStatus(params)
+    const result = await routeUseCase.updateRouteStatus(params)
     expect(result.map(r => r.routed)).toEqual([false])
   })
 
@@ -125,12 +127,12 @@ describe('Routes manifest use case', () => {
     const secondDeployment = deploymentFixture
     firstDeployment.cdConfiguration = configuration
     firstDeployment.circleId = firstCircleId
-    await repo.save(firstDeployment)
+    await deploymentRepository.save(firstDeployment)
 
     secondDeployment.cdConfiguration = configuration
     secondDeployment.circleId = secondCircleId
     secondDeployment.id = 'a7d08a07-f29d-452e-a667-7a39820f3262'
-    await repo.save(secondDeployment)
+    await deploymentRepository.save(secondDeployment)
 
     const params = [
       {
@@ -171,7 +173,7 @@ describe('Routes manifest use case', () => {
       }
     ]
 
-    const result = await routeUseCase.updateHealthStatus(params)
+    const result = await routeUseCase.updateRouteStatus(params)
     expect(result.map(r => ({ circle: r.circleId, routed: r.routed }))).toEqual(
       [
         { circle: firstCircleId, routed: true },

--- a/butler/src/tests/v2/unit/operator/create-routes-manifests-usecase.spec.ts
+++ b/butler/src/tests/v2/unit/operator/create-routes-manifests-usecase.spec.ts
@@ -69,6 +69,7 @@ describe('Hook Routes Manifest Creation', () => {
   })
 
   it('generate route manifest correctly', async() => {
+    jest.spyOn(deploymentRepository, 'updateRouteStatus').mockImplementation(async() => deploymentFixture)
     const routeUseCase = new CreateRoutesManifestsUseCase(
       deploymentRepository,
       componentsRepository,
@@ -78,7 +79,7 @@ describe('Hook Routes Manifest Creation', () => {
 
     const manifests = await routeUseCase.execute(hookParams)
 
-    expect(manifests).toEqual({ children: routesManifests })
+    expect(manifests).toEqual({ children: routesManifests, resyncAfterSeconds: 5 })
   })
 
   it('throws exception when manifests generation fail', async() => {
@@ -175,7 +176,9 @@ describe('Compare observed routes state with desired routes state', () => {
             metadata: {
               name: 'abobora',
               namespace: 'default',
-              circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+              annotations: {
+                circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+              }
             }
           },
           jilo: {
@@ -183,7 +186,9 @@ describe('Compare observed routes state with desired routes state', () => {
             metadata: {
               name: 'abobora',
               namespace: 'default',
-              circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+              annotations: {
+                circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+              }
             }
           }
         },
@@ -193,7 +198,9 @@ describe('Compare observed routes state with desired routes state', () => {
             metadata: {
               name: 'abobora',
               namespace: 'default',
-              circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+              annotations: {
+                circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+              }
             }
           },
           jilo: {
@@ -201,7 +208,9 @@ describe('Compare observed routes state with desired routes state', () => {
             metadata: {
               name: 'jilo',
               namespace: 'default',
-              circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+              annotations: {
+                circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+              }
             }
           }
         }
@@ -214,7 +223,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'jilo',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         }
       },
       {
@@ -222,7 +233,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'jilo',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         },
       },
       {
@@ -230,7 +243,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'abobora',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         }
       },
       {
@@ -238,7 +253,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'abobora',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         }
       }
     ]
@@ -318,7 +335,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'jilo',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         }
       },
       {
@@ -326,7 +345,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'jilo',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         }
       },
       {
@@ -334,7 +355,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'abobora',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         },
       },
       {
@@ -342,7 +365,9 @@ describe('Compare observed routes state with desired routes state', () => {
         metadata: {
           name: 'abobora',
           namespace: 'default',
-          circles: ['ad2a1669-34b8-4af2-b42c-acbad2ec6b60']
+          annotations: {
+            circles: '["ad2a1669-34b8-4af2-b42c-acbad2ec6b60"]'
+          }
         }
       }
     ]

--- a/butler/src/tests/v2/unit/operator/create-routes-manifests-usecase.spec.ts
+++ b/butler/src/tests/v2/unit/operator/create-routes-manifests-usecase.spec.ts
@@ -70,6 +70,7 @@ describe('Hook Routes Manifest Creation', () => {
 
   it('generate route manifest correctly', async() => {
     jest.spyOn(deploymentRepository, 'updateRouteStatus').mockImplementation(async() => deploymentFixture)
+    jest.spyOn(componentsRepository, 'findHealthyActiveComponents').mockImplementation(async() => deployComponentsFixture)
     const routeUseCase = new CreateRoutesManifestsUseCase(
       deploymentRepository,
       componentsRepository,

--- a/butler/src/tests/v2/unit/operator/reconcile.spec.ts
+++ b/butler/src/tests/v2/unit/operator/reconcile.spec.ts
@@ -5,20 +5,20 @@ import { ComponentEntityV2 } from '../../../../app/v2/api/deployments/entity/com
 import { DeploymentEntityV2 } from '../../../../app/v2/api/deployments/entity/deployment.entity'
 import { GitProvidersEnum } from '../../../../app/v2/core/configuration/interfaces/git-providers.type'
 import { ClusterProviderEnum } from '../../../../app/v2/core/integrations/octopipe/interfaces/octopipe-payload.interface'
-import { Reconcile } from '../../../../app/v2/operator/reconcile'
+import { ReconcileDeployment } from '../../../../app/v2/operator/use-cases/reconcile-deployments.usecase'
 import { reconcileFixtures, reconcileFixturesParams } from './params'
 
 describe('Deployment on existing circle', () => {
   it('returns empty array for the first reconcile loop on same circle that already had deployments', () => {
     const params = reconcileFixturesParams.paramsWithPreviousDeployment
     const currentDeployment = reconcileFixtures.currentDeploymentId
-    const reconcile = new Reconcile()
+    const reconcile = new ReconcileDeployment()
     expect(reconcile.specsByDeployment(params, currentDeployment)).toEqual([])
   })
   it('returns list of previous deployment specs', () => {
     const params = reconcileFixturesParams.paramsWithPreviousDeployment
     const previousDeployment = reconcileFixtures.previousDeploymentId
-    const reconcile = new Reconcile()
+    const reconcile = new ReconcileDeployment()
     const ids = reconcile.specsByDeployment(params, previousDeployment).map(s => s.metadata.labels.deployment_id)
     expect(ids).toEqual([previousDeployment, previousDeployment])
   })
@@ -27,7 +27,7 @@ describe('Deployment on existing circle', () => {
     const params = reconcileFixturesParams.paramsWithPreviousDeployment
     const previousDeployment = reconcileFixtures.previousDeploymentId
     const currentDeployment = reconcileFixtures.currentDeploymentId
-    const reconcile = new Reconcile()
+    const reconcile = new ReconcileDeployment()
     const currentSpecs = reconcile.specsByDeployment(params, currentDeployment)
     const previousSpecs = reconcile.specsByDeployment(params, previousDeployment)
     expect(reconcile.checkConditions(currentSpecs)).toEqual(false)
@@ -35,7 +35,7 @@ describe('Deployment on existing circle', () => {
   })
 
   it('concatenates deployments and services from previous and current deployment', () => {
-    const reconcile = new Reconcile()
+    const reconcile = new ReconcileDeployment()
     const cdConfig = new CdConfigurationEntity(
       CdTypeEnum.OCTOPIPE,
       { provider: ClusterProviderEnum.DEFAULT, gitProvider: GitProvidersEnum.GITHUB, gitToken: 'my-token', namespace: 'my-namespace' },

--- a/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-circle-dr.ts
@@ -4,10 +4,9 @@ export const noRepeatedCircleDr = {
   metadata: {
     name: 'A',
     namespace: 'sandbox',
-    circles: [
-      'default-circle-id',
-      'normal-circle-id'
-    ]
+    annotations: {
+      circles: '["default-circle-id","normal-circle-id"]'
+    }
   },
   spec: {
     host: 'A',

--- a/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-circle-dr.ts
@@ -3,7 +3,11 @@ export const noRepeatedCircleDr = {
   kind: 'DestinationRule',
   metadata: {
     name: 'A',
-    namespace: 'sandbox'
+    namespace: 'sandbox',
+    circles: [
+      'default-circle-id',
+      'normal-circle-id'
+    ]
   },
   spec: {
     host: 'A',

--- a/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-default-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-default-circle-dr.ts
@@ -3,7 +3,11 @@ export const noRepeatedDefaultCircleDr = {
   kind: 'DestinationRule',
   metadata: {
     name: 'A',
-    namespace: 'sandbox'
+    namespace: 'sandbox',
+    circles: [
+      'default-circle-id',
+      'normal-circle-id'
+    ]
   },
   spec: {
     host: 'A',

--- a/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-default-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/deployment/no-repeated-default-circle-dr.ts
@@ -4,10 +4,9 @@ export const noRepeatedDefaultCircleDr = {
   metadata: {
     name: 'A',
     namespace: 'sandbox',
-    circles: [
-      'default-circle-id',
-      'normal-circle-id'
-    ]
+    annotations: {
+      circles: '["default-circle-id","normal-circle-id"]'
+    }
   },
   spec: {
     host: 'A',

--- a/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-circle-dr.ts
@@ -3,7 +3,10 @@ export const noRepeatedUndeploymentCircleDr = {
   kind: 'DestinationRule',
   metadata: {
     name: 'A',
-    namespace: 'sandbox'
+    namespace: 'sandbox',
+    circles: [
+      'default-circle-id'
+    ]
   },
   spec: {
     host: 'A',

--- a/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-circle-dr.ts
@@ -4,9 +4,9 @@ export const noRepeatedUndeploymentCircleDr = {
   metadata: {
     name: 'A',
     namespace: 'sandbox',
-    circles: [
-      'default-circle-id'
-    ]
+    annotations: {
+      circles: '["default-circle-id"]'
+    }
   },
   spec: {
     host: 'A',

--- a/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-default-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-default-circle-dr.ts
@@ -4,9 +4,9 @@ export const noRepeatedUndeploymentDefaultCircleDr = {
   metadata: {
     name: 'A',
     namespace: 'sandbox',
-    circles: [
-      'normal-circle-id'
-    ]
+    annotations: {
+      circles: '["normal-circle-id"]'
+    }
   },
   spec: {
     host: 'A',

--- a/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-default-circle-dr.ts
+++ b/butler/src/tests/v2/unit/utils/fixtures/undeployment/no-repeated-undeployment-default-circle-dr.ts
@@ -3,7 +3,10 @@ export const noRepeatedUndeploymentDefaultCircleDr = {
   kind: 'DestinationRule',
   metadata: {
     name: 'A',
-    namespace: 'sandbox'
+    namespace: 'sandbox',
+    circles: [
+      'normal-circle-id'
+    ]
   },
   spec: {
     host: 'A',


### PR DESCRIPTION
Update `routed` column on `v2deployments` table on each reconcile loop.
If all desired components+circles are found on the observed state we set the column to true.

To make it easier to perform de "diff" of the observed stated and desired state I introduced a new annotation to the VirtualService and DestinationRule manifests.

```
annotations: {
  circles: '["some-circle-id", "another-circle-id"]'
 }
 ```
Since the annotation fields can only be a key/value pair of strings we have to json encode the circle id list to a string, and decode it when reading the field. This will also be relevant when discussing a future feature to add user defined metadata to the deployments.