### PR TITLE
fix moove not returning circle deployment

### DIFF
--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/repository/JdbcDeploymentRepository.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/repository/JdbcDeploymentRepository.kt
@@ -252,7 +252,7 @@ class JdbcDeploymentRepository(
 
         return this.jdbcTemplate.query(
             statement.toString(),
-            arrayOf(circleId, workspaceId),
+            arrayOf(workspaceId, circleId),
             deploymentExtractor
         )?.toList() ?: emptyList()
     }


### PR DESCRIPTION
Signed-off-by: thalles freitas <thalles.freitas@zup.com.br>

## Issue Description
Moove is not returning the right circle payload with deployment

## Solution
Fix query that has the wrong order of query parameters sent