### PR TITLE
Chart job init db

### DIFF
--- a/install/helm-chart/Chart.yaml
+++ b/install/helm-chart/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.7
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/install/helm-chart/templates/deployment.yaml
+++ b/install/helm-chart/templates/deployment.yaml
@@ -31,8 +31,11 @@ spec:
       initContainers:
         - name: check-db-ready
           image: postgres:9.6.5
+          env:
+              - name: PGPASSWORD
+                value: {{ .database.password}}
           command: ['sh', '-c', 
-            'until pg_isready -h {{ .database.host }} -p 5432; 
+            'until pg_isready -h {{ .database.host }} -p 5432 -d {{ .database.name }} -U {{ .database.user}};
             do echo waiting for database; sleep 2; done;']
     {{- end }}
     {{- with .imagePullSecrets }}

--- a/install/helm-chart/templates/initdb-job.yaml
+++ b/install/helm-chart/templates/initdb-job.yaml
@@ -1,0 +1,51 @@
+{{ if not .Values.postgresql.enabled}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: {{ .Release.Name }}-{{ .Values.job.name }}
+    namespace: {{ .Release.Namespace }}
+spec:
+    backoffLimit: 20
+    template:
+        spec:
+            restartPolicy: OnFailure
+            volumes:
+                -   name: {{ .Release.Name }}-{{ .Values.job.name }}-volume
+                    configMap:
+                        name: {{ .Values.postgresql.initdbScriptsConfigMap }}
+                        defaultMode: 0777
+            initContainers:
+                -   name: check-db-ready
+                    image: "postgres:9.6.5"
+                    imagePullPolicy: Always
+                    resources: { }
+                    command:
+                        - sh
+                        - -c
+                        - until pg_isready -h {{ .Values.postgresqlGlobal.host }} -p 5432; do echo waiting for database; sleep 2; done;
+            containers:
+                -   name: {{ .Release.Name }}-{{ .Values.job.name }}
+                    image: "postgres:9.6.5"
+                    imagePullPolicy: Always
+                    command: ["/bin/sh"]
+                    args: ["/tmp/charles-init.sh"]
+                    env:
+                        -   name: PGUSER
+                            value: {{ .Values.postgresql.pguser }}
+                        -   name: PGPASSWORD
+                            value: {{ .Values.postgresql.pgpassword }}
+                        -   name: PGHOST
+                            value: {{ .Values.postgresqlGlobal.host }}
+                    resources:
+                        requests:
+                            cpu: "{{ .Values.postgresql.resources.requests.cpu }}"
+                            memory: "{{ .Values.postgresql.resources.requests.memory }}"
+                        limits:
+                            cpu: "{{ .Values.postgresql.resources.requests.cpu }}"
+                            memory: "{{ .Values.postgresql.resources.requests.memory }}"
+                    volumeMounts:
+                        -   mountPath: /tmp/charles-init.sh
+                            name: {{ .Release.Name }}-{{ .Values.job.name }}-volume
+                            subPath: charles-init.sh
+{{- end -}}

--- a/install/helm-chart/templates/postgres-cm.yaml
+++ b/install/helm-chart/templates/postgres-cm.yaml
@@ -2,28 +2,41 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: charles-postgres
+  {{- if not .Values.postgresql.enabled }}
+  annotations:
+      "helm.sh/hook": "pre-install"
+  {{- end }}
 data:
   charles-init.sh: |
     #!/bin/bash
-    export PGUSER=postgres
-    export PGPASSWORD=firstpassword
-    psql -c "CREATE DATABASE charlescd_butler"
-    psql -c "CREATE USER charlescd_butler WITH PASSWORD '3f2Yq8R4HhDCnefR'"
-    psql -c "ALTER DATABASE charlescd_butler OWNER TO charlescd_butler"
-    psql -d charlescd_butler -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
-    psql -c "CREATE DATABASE charlescd_moove"
-    psql -c "CREATE USER charlescd_moove WITH PASSWORD '7Qs2KuM9gYzw48BS'"
-    psql -c "ALTER DATABASE charlescd_moove OWNER TO charlescd_moove"
-    psql -d charlescd_moove -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
-    psql -c "CREATE DATABASE charlescd_villager"
-    psql -c "CREATE USER charlescd_villager WITH PASSWORD 'ZkQ67Lnhs2bM3MPN'"
-    psql -c "ALTER DATABASE charlescd_villager OWNER TO charlescd_villager"
-    psql -d charlescd_villager -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
-    psql -c "CREATE DATABASE keycloak"
-    psql -c "CREATE USER keycloak WITH PASSWORD 'DCWYW66Mq2ca6w8u'"
-    psql -c "ALTER DATABASE keycloak OWNER TO keycloak"
-
-    psql -c "CREATE DATABASE charlescd_compass"
-    psql -c "CREATE USER charlescd_compass WITH PASSWORD 'C1UinUu6N0vc'"
-    psql -c "ALTER DATABASE charlescd_compass OWNER TO charlescd_compass"
-    psql -d charlescd_compass -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+    {{- if .Values.postgresql.enabled -}}
+    {{- range .Values.CharlesApplications -}}
+    {{ if .database }}
+      psql -c "CREATE DATABASE {{ .database.name }}"
+      psql -c "CREATE USER {{ .database.user }} WITH PASSWORD '{{ .database.password }}'"
+      psql -c "ALTER DATABASE {{ .database.name }} OWNER TO {{ .database.user }}"
+      psql -d {{ .database.name }} -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+    {{ end }}
+    {{- end -}}
+    {{ if .Values.keycloak.enabled }}
+      psql -c "CREATE DATABASE {{ .Values.keycloak.database.name }}"
+      psql -c "CREATE USER {{ .Values.keycloak.database.user }} WITH PASSWORD '{{ .Values.keycloak.database.password }}'"
+      psql -c "ALTER DATABASE keycloak OWNER TO keycloak"
+    {{ end }}
+    {{ else }}
+    export PGUSER={{ .Values.postgresql.pguser }}
+    export PGPASSWORD={{ .Values.postgresql.pgpassword }}
+    {{- range .Values.CharlesApplications -}}
+    {{ if .database }}
+    psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE {{ .database.name }}"
+    psql -h $PGHOST -U $PGUSER -c "CREATE USER {{ .database.user }} WITH PASSWORD '{{ .database.password }}'"
+    psql -h $PGHOST -U $PGUSER -c  "ALTER DATABASE {{ .database.name }} OWNER TO {{ .database.user }}"
+    psql -h $PGHOST -U $PGUSER -d {{ .database.name }} -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+    {{ end }}
+    {{- end -}}
+    {{ if .Values.keycloak.enabled }}
+    psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE {{ .Values.keycloak.database.name }}"
+    psql -h $PGHOST -U $PGUSER -c "CREATE USER {{ .Values.keycloak.database.user }} WITH PASSWORD '{{ .Values.keycloak.database.password }}'"
+    psql -h $PGHOST -U $PGUSER -c  "ALTER DATABASE keycloak OWNER TO keycloak"
+    {{ end }}
+    {{ end }}

--- a/install/helm-chart/values.yaml
+++ b/install/helm-chart/values.yaml
@@ -1,5 +1,5 @@
 postgresqlGlobal: &postgresInfo
-  host: &postgresHost 192.168.68.101
+  host: &postgresHost charlescd-postgresql
   port: &postgresPort 5432
 
 hostGlobal: &hostGlobal http://charles.info.example

--- a/install/helm-chart/values.yaml
+++ b/install/helm-chart/values.yaml
@@ -1,5 +1,5 @@
 postgresqlGlobal: &postgresInfo
-  host: &postgresHost charlescd-postgresql
+  host: &postgresHost 192.168.68.101
   port: &postgresPort 5432
 
 hostGlobal: &hostGlobal http://charles.info.example
@@ -9,7 +9,7 @@ CharlesApplications:
   butler:
     enabled: true
     name: charlescd-butler
-    sidecarIstio: 
+    sidecarIstio:
       enabled: true
     healthCheck:
       path: /healthcheck
@@ -137,6 +137,7 @@ CharlesApplications:
         - name: http
           port: 8080
     replicaCount: 1
+    database: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -167,6 +168,7 @@ CharlesApplications:
         - name: http
           port: 3000
     replicaCount: 1
+    database: {}
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -203,6 +205,7 @@ CharlesApplications:
         - name: http
           port: 8080
     replicaCount: 1
+    database: {}
     hpa: true
     autoscaling:
       minReplicas: 1
@@ -288,6 +291,11 @@ postgresql:
   enabled: true
   fullnameOverride: *postgresHost
   initdbScriptsConfigMap: charles-postgres
+  pguser: postgres
+  pgpassword: postgres
+
+job:
+  name: init-db
 
 redis:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Felipe Brunelli de Andrade <felipe.andrade@zup.com.br>

## Issue Description

When a external database is used, init-db scripts are not executed

## Solution

When is set to use external postgres database, we create first ConfigMap and Job to prepare the database for CharlesCD

## Results

External Database configured for CharlesCD and after install, all pods are running 