### PR TITLE
remove the actions from module tab when creating

### DIFF
--- a/ui/src/modules/Modules/Comparation/Tab.tsx
+++ b/ui/src/modules/Modules/Comparation/Tab.tsx
@@ -46,6 +46,7 @@ const Tab = ({ param }: Props) => {
   const { getModuleById, response } = useFindModule();
   const { removeModule } = useDeleteModule(module);
   const isLoading = isEmpty(module) && id !== NEW_TAB;
+  const hasTabActions = id !== NEW_TAB && mode !== 'component'; 
 
   useEffect(() => {
     if (response) {
@@ -80,7 +81,7 @@ const Tab = ({ param }: Props) => {
     );
   };
 
-  const renderActions = () => (
+  const renderActions = () => hasTabActions && (
     <Styled.Actions>
       <Dropdown>
         <Can I="write" a="modules" passThrough>


### PR DESCRIPTION
Signed-off-by: Leandro Queiroz <leandroqueiroz92@gmail.com>

## Issue Description

- When creating a new module, when clicking on the EDIT and COPYLINK options, nothing happens, when clicking on the DELETE option, a 404 is returned. 
- When creating a new component in an existing module, when clicking on the COPYLINK option, nothing happens, when clicking on the DELETE and COPYLINK options, these options are related to the module and not to the component. 

## Solution
In these two scenarios, this drop-down list with these options should no longer be displayed. 

