### PR TITLE
Fix list metric prometheus error

### DIFF
--- a/compass/plugins/datasource/prometheus/prometheus.go
+++ b/compass/plugins/datasource/prometheus/prometheus.go
@@ -117,7 +117,9 @@ func GetMetrics(datasourceConfiguration []byte) (datasource.MetricList, error) {
 
 	v1Api := v1.NewAPI(apiClient)
 	namedLabels := "__name__"
-	labelValues, _, err := v1Api.LabelValues(context.Background(), namedLabels, time.Now(), time.Now())
+	endTime := time.Now()
+	startTime := endTime.AddDate(0, 0, -1)
+	labelValues, _, err := v1Api.LabelValues(context.Background(), namedLabels, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Issue Description

Sometimes the list of Prometheus metrics to use in a metric group could be empty.

## Solution

Fixed error where start date parameter was after end date parameter at calling Prometheus API.
