### PR TITLE
Fix showing username undefined in the initial screen

### DIFF
--- a/ui/src/modules/Workspaces/__tests__/Workspaces.spec.tsx
+++ b/ui/src/modules/Workspaces/__tests__/Workspaces.spec.tsx
@@ -22,6 +22,7 @@ import * as WorkspaceHooks from '../hooks';
 import {user} from './fixtures';
 import * as StateHooks from 'core/state/hooks';
 import Workspaces from '../';
+import { saveProfile } from 'core/utils/profile';
 
 const originalWindow = { ...window };
 
@@ -53,7 +54,7 @@ jest.mock('react-cookies', () => {
 });
 
 test('render Workspace modal', async () => {
-  jest.spyOn(authUtils, 'isRoot').mockImplementation(() => true);
+  saveProfile({id: '1', name: 'Charles Admin', email: 'charlesadmin@admin', root: true});
   
   render(<Workspaces selectedWorkspace={jest.fn()} />);
   
@@ -68,12 +69,10 @@ test('render Workspace modal', async () => {
 });
 
 test('render Workspace and see a placeholder', async () => {
-  jest.spyOn(authUtils, 'isRoot').mockImplementation(() => true);
-  jest.spyOn(authUtils, 'getAccessTokenDecoded').mockReturnValue(user);
-  
+  saveProfile({id: '1', name: 'Charles Admin', email: 'charlesadmin@admin', root: true});
   render(<Workspaces selectedWorkspace={jest.fn()} />);
 
-  expect(await screen.findByTestId('placeholder-empty-workspaces')).toBeInTheDocument();
+  expect(await screen.findByTestId('icon-empty-workspaces')).toBeInTheDocument();
   expect(screen.getByText('Hello, Charles Admin!')).toBeInTheDocument();
   expect(screen.getByText('Select or create a workspace in the side menu.')).toBeInTheDocument();
 });

--- a/ui/src/modules/Workspaces/index.tsx
+++ b/ui/src/modules/Workspaces/index.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import Page from 'core/components/Page';
 import Placeholder from 'core/components/Placeholder';
-import { getAccessTokenDecoded, isRoot, logout } from 'core/utils/auth';
+import { isRoot, logout } from 'core/utils/auth';
 import Menu from './Menu';
 import { clearWorkspace } from 'core/utils/workspace';
 import { useSaveWorkspace } from 'modules/Workspaces/hooks';
@@ -29,13 +29,16 @@ import { isRequired, maxLength } from 'core/utils/validations';
 import { removeWizard } from 'modules/Settings/helpers';
 import Modal from 'core/components/Modal';
 import Styled from './styled';
+import { getProfileByKey } from 'core/utils/profile';
 
 interface Props {
   selectedWorkspace: (name: string) => void;
 }
 
 const Workspaces = ({ selectedWorkspace }: Props) => {
-  const { name: profileName, email } = getAccessTokenDecoded();
+  const profileName = getProfileByKey('name');
+  const email = getProfileByKey('email');
+
   const [toggleModal, setToggleModal] = useState(false);
   const {
     save,


### PR DESCRIPTION
Signed-off-by: luanecavalcantizup <luane.cavalcanti@zup.com.br>

## Issue Description

In the initial screen, username is not showing, instead `undefined` is shown.

## Solution

Get profile name from localstorage.

### Screenshots:
![image](https://user-images.githubusercontent.com/74269773/112360631-46365d00-8cb1-11eb-8944-effe3937274f.png)
