### PR TITLE
adding publish verification when subscription not found to an avent

### DIFF
--- a/hermes/web/api/subscription/subscription.go
+++ b/hermes/web/api/subscription/subscription.go
@@ -213,6 +213,11 @@ func Publish(messageMain message.UseCases, subscriptionMain subscription.UseCase
 			restutil.NewResponse(w, http.StatusInternalServerError, sErr)
 			return
 		}
+		
+		if len(subscriptions) <= 0 {
+			restutil.NewResponse(w, http.StatusOK, "No subscription founded to this event")
+			return
+		}
 
 		requestMessages, eventErr := restutil.SubscriptionToMessageRequest(subscriptions, request)
 		if eventErr != nil {


### PR DESCRIPTION
## Issue Description

When a webhook event is trigged and a subscription not exists to this event type an error happens.

## Solution

Adding this verification when publish a message.

## Results

Publish with succes with 200 OK with message "No subscription founded to this event"
