### PR TITLE
Hotfix: duplicated component name should not be allowed

### DIFF
--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/ModuleService.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/ModuleService.kt
@@ -18,10 +18,9 @@
 
 package io.charlescd.moove.application
 
-import io.charlescd.moove.domain.Component
-import io.charlescd.moove.domain.Module
-import io.charlescd.moove.domain.Page
-import io.charlescd.moove.domain.PageRequest
+import io.charlescd.moove.application.module.request.CreateModuleRequest
+import io.charlescd.moove.domain.*
+import io.charlescd.moove.domain.exceptions.BusinessException
 import io.charlescd.moove.domain.exceptions.NotFoundException
 import io.charlescd.moove.domain.repository.ModuleRepository
 import javax.inject.Named
@@ -71,5 +70,11 @@ class ModuleService(private val moduleRepository: ModuleRepository) {
 
     fun findByIdsAndWorkspaceId(ids: List<String>, workspaceId: String): List<Module> {
         return moduleRepository.findByIdsAndWorkpaceId(ids, workspaceId)
+    }
+
+    fun checkIfComponentNameIsDuplicated(componentNames: List<String>) {
+        if (componentNames.groupingBy { it }.eachCount().any { it.value > 1 }) {
+            throw BusinessException.of(MooveErrorCode.DUPLICATED_COMPONENT_NAME_ERROR)
+        }
     }
 }

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/module/impl/CreateModuleInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/module/impl/CreateModuleInteractorImpl.kt
@@ -44,6 +44,8 @@ open class CreateModuleInteractorImpl(
 
         val user = userService.findByAuthorizationToken(authorization)
 
+        moduleService.checkIfComponentNameIsDuplicated(request.components.map { it.name }.toList())
+
         val workspace = workspaceService.find(workspaceId)
 
         if (workspace.status == WorkspaceStatusEnum.INCOMPLETE) {

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/module/impl/UpdateComponentInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/module/impl/UpdateComponentInteractorImpl.kt
@@ -40,17 +40,23 @@ class UpdateComponentInteractorImpl @Inject constructor(private val moduleServic
     ): ComponentResponse {
         val module = moduleService.find(moduleId, workspaceId)
         checkIfComponentExists(module, componentId)
+        validateComponentName(module, componentId, request)
+        val updatedComponent = buildUpdatedComponent(module, componentId, request)
+        moduleService.updateComponent(updatedComponent)
+        return ComponentResponse.from(updatedComponent)
+    }
 
-        if(module.components.find { it.id == componentId }!!.name != request.name) {
+    private fun validateComponentName(
+        module: Module,
+        componentId: String,
+        request: ComponentRequest
+    ) {
+        if (module.components.find { it.id == componentId }!!.name != request.name) {
             val componentNameList = module.components.map { it.name }.toMutableList()
             componentNameList.add(request.name)
 
             moduleService.checkIfComponentNameIsDuplicated(componentNameList)
         }
-
-        val updatedComponent = buildUpdatedComponent(module, componentId, request)
-        moduleService.updateComponent(updatedComponent)
-        return ComponentResponse.from(updatedComponent)
     }
 
     private fun buildUpdatedComponent(

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/module/impl/UpdateComponentInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/module/impl/UpdateComponentInteractorImpl.kt
@@ -40,6 +40,14 @@ class UpdateComponentInteractorImpl @Inject constructor(private val moduleServic
     ): ComponentResponse {
         val module = moduleService.find(moduleId, workspaceId)
         checkIfComponentExists(module, componentId)
+
+        if(module.components.find { it.id == componentId }!!.name != request.name) {
+            val componentNameList = module.components.map { it.name }.toMutableList()
+            componentNameList.add(request.name)
+
+            moduleService.checkIfComponentNameIsDuplicated(componentNameList)
+        }
+
         val updatedComponent = buildUpdatedComponent(module, componentId, request)
         moduleService.updateComponent(updatedComponent)
         return ComponentResponse.from(updatedComponent)

--- a/moove/domain/src/main/kotlin/io/charlescd/moove/domain/MooveErrorCode.kt
+++ b/moove/domain/src/main/kotlin/io/charlescd/moove/domain/MooveErrorCode.kt
@@ -60,5 +60,6 @@ enum class MooveErrorCode(val key: String) {
     CANNOT_RESET_YOUR_OWN_PASSWORD("cannot.reset.your.own.password"),
     EXTERNAL_IDM_FORBIDDEN("external.idm.forbidden"),
     LIMIT_OF_PERCENTAGE_CIRCLES_EXCEEDED("limit.of.percentage.circles.exceeded"),
-    IDM_UNEXPECTED_ERROR("idm.unexpected.error")
+    IDM_UNEXPECTED_ERROR("idm.unexpected.error"),
+    DUPLICATED_COMPONENT_NAME_ERROR("duplicated.component.name.error")
 }

--- a/moove/web/src/main/resources/locale/messages.properties
+++ b/moove/web/src/main/resources/locale/messages.properties
@@ -41,3 +41,4 @@ registry.general.error=Not possible test the registry connection. Try again.
 villager.registry.integration.error=Connection Villager failed. Not possible test the registry connection. Verify if Villager is available.
 villager.unexpected.error=An unexpected error occurred.
 idm.unexpected.error=An unexpected error occurred when trying to reach your identity manager.
+duplicated.component.name.error=You can not save two components with the same name.

--- a/moove/web/src/main/resources/locale/messages_pt_BR.properties
+++ b/moove/web/src/main/resources/locale/messages_pt_BR.properties
@@ -39,3 +39,4 @@ registry.integration.error=Conexão com a API do Registry falhou. Não é possí
 villager.registry.integration.error=Conexão com o Villager falhou. Não é possível testar a conexão com o registry. Verifique se o Villager está disponivel.
 villager.unexpected.error=Um erro inesperado ocorreu.
 idm.unexpected.error=Um erro inesperado ocorreu ao tentar acessar o seu identity manager.
+duplicated.component.name.error=Não é possível salvar dois componentes com o mesmo nome.


### PR DESCRIPTION
## Issue Description

When creating a module or updating a component, the component name should not be equal to another existing one.