### PR TITLE
Inserting circleId in metrics before validate

### DIFF
--- a/compass/Makefile
+++ b/compass/Makefile
@@ -17,6 +17,10 @@ COMPOSE_TESTS=./test/docker-compose.test.yaml
 start:
 				sh build-plugins.sh
 				$(GORUN) $(CMD_PATH)
+
+build-plugin:
+				sh build-plugins.sh
+
 build: 
 				$(GOBUILD) -o $(DIST_PATH)/$(BINARY_NAME) $(CMD_PATH)
 

--- a/compass/internal/configuration/configuration.go
+++ b/compass/internal/configuration/configuration.go
@@ -52,7 +52,7 @@ var initialValues = map[string]string{
 	"REQUESTS_PER_SECOND_LIMIT": "1",
 	"LIMITER_TOKEN_TTL":         "5",
 	"LIMITER_HEADERS_TTL":       "5",
-	"ENCRYPTION_KEY":      "caf5a807-5edd-4580-9149-7a4882755716",
+	"ENCRYPTION_KEY":            "caf5a807-5edd-4580-9149-7a4882755716",
 }
 
 func GetDBConnection(migrationsPath string) (*gorm.DB, error) {

--- a/compass/internal/metricsgroup/metricsgroup.go
+++ b/compass/internal/metricsgroup/metricsgroup.go
@@ -270,7 +270,7 @@ func (main Main) FindById(id string) (MetricsGroup, errors.Error) {
 	metricsGroup := MetricsGroup{}
 	db := main.db.Set("gorm:auto_preload", true).Where("id = ?", id).First(&metricsGroup)
 	if db.Error != nil {
-		return MetricsGroup{}, errors.NewError("FindById error", db.Error.Error()).
+		return MetricsGroup{}, errors.NewError("Find Metric Group By Id error", db.Error.Error()).
 			WithOperations("FindById.First")
 	}
 	return metricsGroup, nil

--- a/compass/web/api/v1/metric/metric.go
+++ b/compass/web/api/v1/metric/metric.go
@@ -40,11 +40,6 @@ func Create(metricMain metric.UseCases, metricsgroupMain metricsgroup.UseCases) 
 			return
 		}
 
-		if err := metricMain.Validate(newMetric); len(err.GetErrors()) > 0 {
-			util.NewResponse(w, http.StatusInternalServerError, err)
-			return
-		}
-
 		metricGroup, err := metricsgroupMain.FindById(metricgroupId)
 		if err != nil {
 			util.NewResponse(w, http.StatusInternalServerError, err)
@@ -53,6 +48,12 @@ func Create(metricMain metric.UseCases, metricsgroupMain metricsgroup.UseCases) 
 
 		newMetric.MetricsGroupID = uuid.MustParse(metricgroupId)
 		newMetric.CircleID = metricGroup.CircleID
+
+		if err := metricMain.Validate(newMetric); len(err.GetErrors()) > 0 {
+			util.NewResponse(w, http.StatusInternalServerError, err)
+			return
+		}
+
 		list, err := metricMain.SaveMetric(newMetric)
 		if err != nil {
 			util.NewResponse(w, http.StatusInternalServerError, err)


### PR DESCRIPTION
## Issue Description

When saving a metric your query returned more than one result.

## Solution

Inject circleId before validate the metric

