### PR TITLE
Added DEPLOYING and UNDEPLOYING status on deploy history list

### DIFF
--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/FindDeploymentsHistoryForCircleInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/FindDeploymentsHistoryForCircleInteractorImpl.kt
@@ -60,6 +60,11 @@ class FindDeploymentsHistoryForCircleInteractorImpl(
 
     private fun mountHistoryFilter(circleId: String) = DeploymentHistoryFilter(
         circlesIds = listOf(circleId),
-        deploymentStatus = listOf(DeploymentStatusEnum.DEPLOYED, DeploymentStatusEnum.NOT_DEPLOYED, DeploymentStatusEnum.DEPLOY_FAILED)
+        deploymentStatus = listOf(
+            DeploymentStatusEnum.DEPLOYING,
+            DeploymentStatusEnum.DEPLOYED,
+            DeploymentStatusEnum.UNDEPLOYING,
+            DeploymentStatusEnum.NOT_DEPLOYED,
+            DeploymentStatusEnum.DEPLOY_FAILED)
     )
 }

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/FindDeploymentsHistoryForCircleInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/FindDeploymentsHistoryForCircleInteractorImplTest.groovy
@@ -75,7 +75,11 @@ class FindDeploymentsHistoryForCircleInteractorImplTest extends Specification {
 
         parameteres.deploymentName == null
         parameteres.periodBefore == null
-        parameteres.deploymentStatus == [DeploymentStatusEnum.DEPLOYED, DeploymentStatusEnum.NOT_DEPLOYED, DeploymentStatusEnum.DEPLOY_FAILED]
+        parameteres.deploymentStatus == [DeploymentStatusEnum.DEPLOYING,
+                                         DeploymentStatusEnum.DEPLOYED,
+                                         DeploymentStatusEnum.UNDEPLOYING,
+                                         DeploymentStatusEnum.NOT_DEPLOYED,
+                                         DeploymentStatusEnum.DEPLOY_FAILED]
         parameteres.circlesIds == [circle]
     }
 


### PR DESCRIPTION
Signed-off-by: Icaro Gabriel Marques Afonso <icaro.afonso@zup.com.br>

## Issue Description

Deploy history don't show deploying and undeployng sattus.

## Solution

Added DEPLOYING and UNDEPLOYING status on filter to find the deploy history list.
