### PR TITLE
Upgrade charlescd-release.yml - Hermes e RabbitMQ

### DIFF
--- a/.github/workflows/charlescd-release.yml
+++ b/.github/workflows/charlescd-release.yml
@@ -342,11 +342,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: QEMU
       uses: docker/setup-qemu-action@v1
-
+    
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-    
+
     - name: Docker Buildx
       uses: docker/setup-buildx-action@v1
 
@@ -370,7 +370,8 @@ jobs:
              build_and_push_release_octopipe,
              build_and_push_release_ui,
              build_and_push_release_villager,
-             build_and_push_release_compass
+             build_and_push_release_compass,
+             build_and_push_release_hermes
     ]
     steps:
       - uses: actions/checkout@v2
@@ -450,5 +451,5 @@ jobs:
       - name: Deploy dev
         uses: WyriHaximus/github-action-helm3@v2.1.3
         with:
-          exec: helm upgrade charlescd ./install/helm-chart/ --install --wait --atomic --values=./values-charles-dev.yaml
+          exec: export RABBITMQ_ERLANG_COOKIE=$(kubectl get secret --namespace default charlescd-rabbitmq -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode) && helm upgrade charlescd ./install/helm-chart/ --install --wait --atomic --values=./values-charles-dev.yaml --set rabbitmq.auth.erlangCookie=$RABBITMQ_ERLANG_COOKIE
           kubeconfig: '${{ secrets.KUBECONFIG_DEV }}'


### PR DESCRIPTION
Signed-off-by: Felipe Brunelli de Andrade <felipe.andrade@zup.com.br>

Upgrade Release Pipeline, adding Hermes and RabbitMQ