### PR TITLE
Update routing when account is clicked

### DIFF
--- a/ui/src/modules/Main/Sidebar/MenuItems/__tests__/MenuItems.spec.tsx
+++ b/ui/src/modules/Main/Sidebar/MenuItems/__tests__/MenuItems.spec.tsx
@@ -21,6 +21,9 @@ import { genMenuId } from 'core/utils/menu';
 import MenuItems from '../index';
 import { saveProfile } from 'core/utils/profile';
 import {dark as sidebarDarkTheme} from 'core/assets/themes/sidebar';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom'
 
 const originalWindow = { ...window };
 
@@ -45,7 +48,7 @@ test('renders sidebar menu Items', async () => {
   const links = screen.getByTestId('sidebar-links');
 
   const workspacesId = genMenuId(routes.workspaces);
-  const accountId = genMenuId(routes.account);
+  const accountId = genMenuId(routes.accountProfile);
 
   expect(screen.getByTestId(workspacesId)).toBeInTheDocument();
   expect(screen.getByTestId(accountId)).toBeInTheDocument();
@@ -67,7 +70,7 @@ test('testing outside click menu Items', async () => {
   const links = screen.getByTestId('sidebar-links');
 
   const workspacesId = genMenuId(routes.workspaces);
-  const accountId = genMenuId(routes.account);
+  const accountId = genMenuId(routes.accountProfile);
 
   expect(screen.getByTestId(workspacesId)).toBeInTheDocument();
   expect(screen.getByTestId(accountId)).toBeInTheDocument();
@@ -86,7 +89,7 @@ test('testing expand menu click', async () => {
   );
   const links = screen.getByTestId('sidebar-links');
   const workspacesId = genMenuId(routes.workspaces);
-  const accountId = genMenuId(routes.account);
+  const accountId = genMenuId(routes.accountProfile);
 
   expect(screen.getByTestId(workspacesId)).toBeInTheDocument();
   expect(screen.getByTestId(accountId)).toBeInTheDocument();
@@ -204,4 +207,25 @@ test('should show main menu', () => {
   expect(screen.queryByText('Users')).not.toBeInTheDocument();
   expect(screen.queryByText('User Group')).not.toBeInTheDocument();
   expect(screen.getByText('Account')).toBeInTheDocument();
+});
+
+test('should render route /account/profile when click on account', () => {
+  const history = createMemoryHistory();
+
+  const {rerender} = render(
+    <Router history={history}>
+      <MenuItems isExpanded expandMenu={() => jest.fn()} />
+    </Router>
+  );
+
+  const menuAccount = screen.getByTestId('menu-account-profile');
+  userEvent.click(menuAccount);
+
+  rerender(
+    <Router history={history}>
+      <MenuItems isExpanded expandMenu={() => jest.fn()} />
+    </Router>
+  );
+
+  expect(history.location.pathname).toBe(routes.accountProfile);
 });

--- a/ui/src/modules/Main/Sidebar/__tests__/Sidebar.spec.tsx
+++ b/ui/src/modules/Main/Sidebar/__tests__/Sidebar.spec.tsx
@@ -53,7 +53,7 @@ test('renders sidebar component', async () => {
   const links = await screen.findByTestId('sidebar-links');
 
   const workspacesId = genMenuId(routes.workspaces);
-  const accountId = genMenuId(routes.account);
+  const accountId = genMenuId(routes.accountProfile);
 
   expect(screen.getByTestId(workspacesId)).toBeInTheDocument();
   expect(screen.getByTestId(accountId)).toBeInTheDocument();

--- a/ui/src/modules/Main/constants.ts
+++ b/ui/src/modules/Main/constants.ts
@@ -69,10 +69,10 @@ export const mainMenu: MenuType[] = [
     to: routes.workspaces
   },
   {
-    id: genMenuId(routes.account),
+    id: genMenuId(routes.accountProfile),
     icon: 'account',
     text: 'Account',
-    to: routes.account
+    to: routes.accountProfile
   }
 ];
 
@@ -96,7 +96,7 @@ export const rootMainMenu: MenuType[] = [
     to: routes.groups
   },
   {
-    id: genMenuId(routes.account),
+    id: genMenuId(routes.accountProfile),
     icon: 'account',
     text: 'Account',
     to: routes.accountProfile

--- a/ui/src/modules/Main/constants.ts
+++ b/ui/src/modules/Main/constants.ts
@@ -99,6 +99,6 @@ export const rootMainMenu: MenuType[] = [
     id: genMenuId(routes.account),
     icon: 'account',
     text: 'Account',
-    to: routes.account
+    to: routes.accountProfile
   }
 ];


### PR DESCRIPTION
Signed-off-by: luanecavalcantizup <luane.cavalcanti@zup.com.br>

Closes #994

## Issue Description

When click on `account`, Profile should be selected.

## Solution

Update menu items `to` prop.
