### PR TITLE
[BUG HUNT] Add clipboard support for HTTP protocol

### DIFF
--- a/ui/src/core/utils/clipboard.ts
+++ b/ui/src/core/utils/clipboard.ts
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const copyToClipboard = (value: string) => {
-  navigator.clipboard.writeText(value);
+  if(navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(value);
+  } else {
+    let copyInput = document.createElement("input");
+    copyInput.value = value;
+    copyInput.style.position = "fixed";
+    copyInput.style.left = "-999999px";
+    copyInput.style.top = "-999999px";
+    document.body.appendChild(copyInput);
+    
+    copyInput.focus();
+    copyInput.select();
+    document.execCommand("copy");
+
+    copyInput.remove();
+  }
 };

--- a/ui/src/core/utils/clipboard.ts
+++ b/ui/src/core/utils/clipboard.ts
@@ -15,7 +15,7 @@
  */
 
 export const copyToClipboard = (value: string) => {
-  if(navigator.clipboard && window.isSecureContext) {
+  if(navigator.clipboard) {
     navigator.clipboard.writeText(value);
   } else {
     let copyInput = document.createElement("input");

--- a/ui/src/core/utils/clipboard.ts
+++ b/ui/src/core/utils/clipboard.ts
@@ -20,12 +20,8 @@ export const copyToClipboard = (value: string) => {
   } else {
     let copyInput = document.createElement("input");
     copyInput.value = value;
-    copyInput.style.position = "fixed";
-    copyInput.style.left = "-999999px";
-    copyInput.style.top = "-999999px";
     document.body.appendChild(copyInput);
     
-    copyInput.focus();
     copyInput.select();
     document.execCommand("copy");
 

--- a/ui/src/modules/Settings/Credentials/index.tsx
+++ b/ui/src/modules/Settings/Credentials/index.tsx
@@ -18,7 +18,6 @@ import React, { useState, useEffect } from 'react';
 import useForm from 'core/hooks/useForm';
 import isEmpty from 'lodash/isEmpty';
 import isNull from 'lodash/isNull';
-import { copyToClipboard } from 'core/utils/clipboard';
 import { useWorkspace } from 'modules/Settings/hooks';
 import { useActionData } from './Sections/MetricAction/hooks';
 import { getWorkspaceId } from 'core/utils/workspace';
@@ -33,6 +32,7 @@ import Styled from './styled';
 import Dropdown from 'core/components/Dropdown';
 import { useDatasource } from './Sections/MetricProvider/hooks';
 import { Datasource } from './Sections/MetricProvider/interfaces';
+import { copyToClipboard } from 'core/utils/clipboard';
 
 interface Props {
   onClickHelp?: (status: boolean) => void;
@@ -61,7 +61,6 @@ const Credentials = ({ onClickHelp }: Props) => {
   const { register, handleSubmit, errors } = useForm<FormState>({
     mode: 'onChange'
   });
-
   const handleSaveClick = ({ name }: Record<string, string>) => {
     updateWorkspace(name);
   };

--- a/ui/src/modules/Settings/Credentials/index.tsx
+++ b/ui/src/modules/Settings/Credentials/index.tsx
@@ -61,6 +61,7 @@ const Credentials = ({ onClickHelp }: Props) => {
   const { register, handleSubmit, errors } = useForm<FormState>({
     mode: 'onChange'
   });
+  
   const handleSaveClick = ({ name }: Record<string, string>) => {
     updateWorkspace(name);
   };


### PR DESCRIPTION
Signed-off-by: luanecavalcantizup <luane.cavalcanti@zup.com.br>

## Issue Description

A user could not use any copy functionality when on a HTTP protocol.

## Solution

When it is a HTTP protocol, then clipboard is done through execCommand('copy').