### PR TITLE
Remove unnecessary id from log response

### DIFF
--- a/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/FindDeploymentLogsInteractorTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/FindDeploymentLogsInteractorTest.groovy
@@ -57,7 +57,6 @@ class FindDeploymentLogsInteractorTest extends Specification {
         def deploymentConfiguration = TestUtils.deploymentConfig
         def log = new Log("INFO", "log title", "log details", LocalDateTime.now().toString())
         def logResponse = new LogResponse(
-                "id",
                 [log]
         )
 

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/LogResponse.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/LogResponse.kt
@@ -17,7 +17,6 @@
 package io.charlescd.moove.infrastructure.service.client.response
 
 data class LogResponse(
-    val id: String,
     val logs: List<Log>
 )
 


### PR DESCRIPTION
O id no LogResponse não é mais necessario. Foi removido.