### PR TITLE
[BUG HUNT] Fix users listing in user group modal

### DIFF
--- a/ui/src/modules/Groups/Tabs/Modal/__tests__/Modal.spec.tsx
+++ b/ui/src/modules/Groups/Tabs/Modal/__tests__/Modal.spec.tsx
@@ -31,6 +31,20 @@ test('render users Modal', async () => {
   expect(button).toBeInTheDocument();
 });
 
+test('should not show empty placeholder', async () => {
+  render(
+    <Modal users={users} isOpen onSearch={jest.fn()} onSelected={jest.fn()} />
+  );
+
+  const element = screen.getByTestId('modal-user');
+  const button = screen.getByTestId('button-default-undefined');
+  const placeholder = screen.queryByTestId('icon-user-not-found');
+
+  expect(element).toBeInTheDocument();
+  expect(button).toBeInTheDocument();
+  expect(placeholder).not.toBeInTheDocument();
+});
+
 test('testing on selected style', async () => {
   render(
     <Modal users={users} isOpen onSearch={jest.fn()} onSelected={jest.fn()} />

--- a/ui/src/modules/Groups/Tabs/helpers.ts
+++ b/ui/src/modules/Groups/Tabs/helpers.ts
@@ -18,7 +18,6 @@ import { User } from 'modules/Users/interfaces/User';
 import map from 'lodash/map';
 import filter from 'lodash/filter';
 import some from 'lodash/some';
-import isEmpty from 'lodash/isEmpty';
 import { UserChecked } from '../interfaces/UserChecked';
 
 const filterSelectedUsers = (selectedUsers: UserChecked[], search: string) =>
@@ -55,10 +54,6 @@ export const diffCheckedUsers = (
     ...user,
     checked: false
   }));
-
-  if (isEmpty(search)) {
-    return mappedSelectedUsers;
-  }
 
   const filteredSelectedUsers = filterSelectedUsers(
     mappedSelectedUsers,


### PR DESCRIPTION
Signed-off-by: luanecavalcantizup luane.cavalcanti@zup.com.br

## Issue Description
When I first open user group modal to add users, the users list is empty.

## Solution
Remove conditional that shows only selected users when search is empty.