### PR TITLE
Adding ellipsis for items

### DIFF
--- a/ui/src/modules/Groups/Menu/MenuItem.tsx
+++ b/ui/src/modules/Groups/Menu/MenuItem.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import Text from 'core/components/Text';
 import Styled from './styled';
 
 interface Props {
@@ -32,7 +30,7 @@ const MenuItem = ({ id, name, onSelect, isActive }: Props) => (
     data-testid={`group-menu-item-${id}`}
   >
     <Styled.ListItem icon="users" marginContent="8px">
-      <Text.h4 color="light">{name}</Text.h4>
+      <Styled.Item color="light">{name}</Styled.Item>
     </Styled.ListItem>
   </Styled.Link>
 );

--- a/ui/src/modules/Groups/Menu/styled.ts
+++ b/ui/src/modules/Groups/Menu/styled.ts
@@ -20,7 +20,7 @@ import SearchInputComponent from 'core/components/Form/SearchInput';
 import IconComponent from 'core/components/Icon';
 import ButtonComponent from 'core/components/Button';
 import Form from 'core/components/Form';
-import Text from 'core/components/Text';
+import ComponentText from 'core/components/Text';
 import { COLOR_BLACK_MARLIN } from 'core/assets/colors';
 import LoaderMenuComponent from './Loaders';
 
@@ -34,6 +34,12 @@ const ListItem = styled(LabeledIcon)`
   cursor: pointer;
   display: flex;
 `;
+
+const Item = styled(ComponentText.h4)`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 240px;
+`
 
 const Content = styled.div`
   height: calc(100vh - 250px);
@@ -80,7 +86,7 @@ const ModalInput = styled(Form.Input)`
   }
 `;
 
-const ModalTitle = styled(Text.h2)`
+const ModalTitle = styled(ComponentText.h2)`
   margin-bottom: 20px;
 `;
 
@@ -101,6 +107,7 @@ const Empty = styled.div`
 export default {
   SearchInput,
   ListItem,
+  Item,
   Content,
   Actions,
   Icon,

--- a/ui/src/modules/Groups/Tabs/Modal/index.tsx
+++ b/ui/src/modules/Groups/Tabs/Modal/index.tsx
@@ -75,10 +75,10 @@ const UserItem = ({ id, name, email, checked, onSelected }: UserItemProps) => {
     <Styled.Item.Wrapper key={`user-item-${id}`} onClick={() => handleSelected(id)}>
       <Styled.Item.Profile>
         <Styled.Item.Photo name={name} />
-        <div>
-          <Styled.Item.Name>{name}</Styled.Item.Name>
-          <Styled.Item.Email>{email}</Styled.Item.Email>
-        </div>
+        <Styled.Item.Content>
+          <Styled.Item.Name color="light">{name}</Styled.Item.Name>
+          <Styled.Item.Email color="light">{email}</Styled.Item.Email>
+        </Styled.Item.Content>
       </Styled.Item.Profile>
       <MemberChecked checked={isChecked} onSelected={onSelected} />
     </Styled.Item.Wrapper>

--- a/ui/src/modules/Groups/Tabs/Modal/styled.ts
+++ b/ui/src/modules/Groups/Tabs/Modal/styled.ts
@@ -17,6 +17,7 @@
 import styled from 'styled-components';
 import { COLOR_BLACK_MARLIN } from 'core/assets/colors';
 import AvatarName from 'core/components/AvatarName';
+import ComponentText from 'core/components/Text';
 import { Input } from 'core/components/Form';
 
 interface WrapperProps {
@@ -122,6 +123,10 @@ const ItemWrapper = styled.div`
   background: ${({ theme }) => theme.modal.default.background};
 `;
 
+const ItemContent = styled.div`
+  width: 350px;
+`;
+
 const ItemProfile = styled.div`
   display: flex;
   flex-direction: row;
@@ -134,13 +139,17 @@ const ItemPhoto = styled(AvatarName)`
   margin-right: 10px;
 `;
 
-const ItemName = styled.div`
+const ItemName = styled(ComponentText.h4)`
   font-size: 14px;
   font-weight: 900;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
-const ItemEmail = styled.div`
+const ItemEmail = styled(ComponentText.h4)`
   font-weight: 300;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
 const CloseButton = styled.div`
@@ -173,6 +182,7 @@ export default {
   Label,
   Item: {
     Wrapper: ItemWrapper,
+    Content: ItemContent,
     Profile: ItemProfile,
     Photo: ItemPhoto,
     Name: ItemName,


### PR DESCRIPTION
## Issue Description

_Quando eu tenho um user com email e/ou nome com valores muito grandes (ex: 64 caracteres), ao ir para a tela para associar o usuário a user group, não aparece o botão +, pois o nome não fica delimitado. Já tem um usuário com essas características, para reproduzir, basta adicionar ele em um user group._

## Solution

- Adicionado `text-ellipsis` e algumas propriedades para que o texto não quebre o layout quando passar da margem.
