### PR TITLE
Adding margin for subtitle in editing mode

### DIFF
--- a/ui/src/core/components/Text/index.tsx
+++ b/ui/src/core/components/Text/index.tsx
@@ -18,7 +18,7 @@ import React, { ReactNode } from 'react';
 import Styled from './styled';
 import { HEADINGS_FONT_SIZE } from './enums';
 
-interface Props {
+export interface Props {
   fontSize?: HEADINGS_FONT_SIZE;
   color?: string;
   fontStyle?: 'normal' | 'italic' | 'oblique';

--- a/ui/src/modules/Modules/Comparation/Form/index.tsx
+++ b/ui/src/modules/Modules/Comparation/Form/index.tsx
@@ -216,7 +216,7 @@ const FormModule = ({ module, onChange }: Props) => {
           description="To configure a module you need to register a Git URL and enter the Helm repository URL. You will need to insert the components in the next step. See our documentation for further details."
         />
       </Styled.Title>
-      <Styled.Subtitle color="dark">
+      <Styled.Subtitle isEditing={isEditing} color="dark">
         Enter the requested information below:
       </Styled.Subtitle>
       <FormProvider {...form}>

--- a/ui/src/modules/Modules/Comparation/Form/styled.ts
+++ b/ui/src/modules/Modules/Comparation/Form/styled.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import FormComponent from 'core/components/Form';
 import ComponentPopover, {
   Props as PopoverProps
 } from 'core/components/Popover';
 import ButtonComponent from 'core/components/Button';
 import IconComponent from 'core/components/Icon';
-import Text from 'core/components/Text';
+import Text, { Props as TextProps } from 'core/components/Text';
 import { slideInRight } from 'core/assets/style/animate';
 
 const Title = styled(Text.h2)`
@@ -33,8 +33,16 @@ const Title = styled(Text.h2)`
   }
 `;
 
-const Subtitle = styled(Text.h5)`
+interface StyledSubtitle extends TextProps {
+  isEditing?: boolean;
+}
+
+const Subtitle = styled(Text.h5)<StyledSubtitle>`
   margin: 20px 0px 5px;
+
+  ${({ isEditing }) => isEditing && css`
+    margin-bottom: 25px;
+  `};
 `;
 
 const Options = styled(Text.h5)`


### PR DESCRIPTION
## Issue Description

_Tela de modules texto "Enter the requested information below:" falta espaçamento_
by @SchumaiquerZup 

## Why this happens

O espaçamento existia, mas no modo de edição o label/placeholder do campo inferior levanta porquê contém dados e com isso a impressão de não haver espaço entre subtítulo e o primeiro campo.

## Solution

- Adicionado margem no subtítulo quando formulário estiver no modo de edição.
