### PR TITLE
Bug hunt metric actions fix

### DIFF
--- a/ui/src/modules/Settings/Credentials/Sections/MetricAction/Form.tsx
+++ b/ui/src/modules/Settings/Credentials/Sections/MetricAction/Form.tsx
@@ -25,7 +25,13 @@ import Styled from './styled';
 import { ActionForm, ActionPayload } from './types';
 import { buildActionPayload } from './helpers';
 import DocumentationLink from 'core/components/DocumentationLink';
-import { isRequiredAndNotBlank } from 'core/utils/validations';
+import { 
+  isRequired,
+  urlPattern,
+  isRequiredAndNotBlank,
+  isNotBlank,
+  trimValue
+} from 'core/utils/validations';
 
 const actionPlaceholder = 'charlescd-custom-path-example';
 
@@ -46,6 +52,7 @@ const FormAddAction = ({ onFinish }: Props<ActionForm>) => {
     register,
     control,
     watch,
+    errors,
     formState: { isValid }
   } = formMethods;
   const nickname = watch('nickname') as string;
@@ -113,7 +120,15 @@ const FormAddAction = ({ onFinish }: Props<ActionForm>) => {
         <Styled.Wrapper>
           <Styled.Input
             name="configuration"
-            ref={register(isRequiredAndNotBlank)}
+            ref={register({
+              required: isRequired(),
+              validate: {
+                notBlank: isNotBlank
+              },
+              setValueAs: trimValue,
+              pattern: urlPattern()
+            })}
+            error={errors?.configuration?.message}
             label="Enter a action configuration"
           />
           {showPlaceholder && (
@@ -173,7 +188,7 @@ const FormAddAction = ({ onFinish }: Props<ActionForm>) => {
         You can create an action and add a trigger to perform an automatic task.
         Consult our{' '}
         <DocumentationLink
-          documentationLink="https://docs.charlescd.io/reference/metrics/metrics-actions"
+          documentationLink="https://docs.charlescd.io/reference/metrics/action"
           text="documentation"
         />
         for further details.

--- a/ui/src/modules/Settings/Credentials/Sections/MetricAction/hooks.ts
+++ b/ui/src/modules/Settings/Credentials/Sections/MetricAction/hooks.ts
@@ -119,6 +119,7 @@ export const useCreateAction = () => {
   const createActionPayload = useFetchData<ActionPayload>(createActionRequest);
   const status = useFetchStatus();
   const [validationError, setValidationError] = useState<ValidationError>();
+  const dispatch = useDispatch();
 
   const createAction = useCallback(
     async (actionPayload: ActionPayload) => {
@@ -134,10 +135,16 @@ export const useCreateAction = () => {
         e.text().then((errorMessage: string) => {
           const parsedError = JSON.parse(errorMessage);
           setValidationError(parsedError);
+          dispatch(
+            toogleNotification({
+              text: parsedError,
+              status: 'error'
+            })
+          );
         });
       }
     },
-    [createActionPayload, status]
+    [createActionPayload, status, dispatch]
   );
 
   return {

--- a/ui/src/modules/Settings/Credentials/Sections/MetricAction/styled.ts
+++ b/ui/src/modules/Settings/Credentials/Sections/MetricAction/styled.ts
@@ -142,6 +142,7 @@ const Placeholder = styled(TextComponent.h4)`
 
 const Wrapper = styled.div`
   position: relative;
+  padding-bottom: 10px;
 `;
 
 export default {


### PR DESCRIPTION
[UI] Link da documentacao de metricas é inválido na tela workspace/settings/credentials/metric action (https://docs.charlescd.io/reference/metrics/metrics-actions)

[UI] Não está salvando uma metric action com a opção Custom Path (backend retornando 500 e o frontend não exibe nada)