### PR TITLE
Fix vertical align for InputTitle

### DIFF
--- a/ui/src/core/components/Form/InputTitle/index.tsx
+++ b/ui/src/core/components/Form/InputTitle/index.tsx
@@ -67,14 +67,14 @@ const InputTitle = React.forwardRef(
     };
 
     return (
-      <Styled.Wrapper ref={wrapperRef}>
+      <Styled.Wrapper ref={wrapperRef} className={className}>
         <Styled.Field>
           <Styled.InputTitle
             readOnly={readOnly}
             name={name}
             ref={inputRef}
             resume={isResumed || readOnly}
-            className={className}
+            className="input-title"
             onClick={() => setIsResumed(false)}
             placeholder={placeholder}
             defaultValue={defaultValue}

--- a/ui/src/modules/Circles/Comparation/Item/styled.ts
+++ b/ui/src/modules/Circles/Comparation/Item/styled.ts
@@ -74,9 +74,11 @@ const Link = styled.a`
 `;
 
 const InputTitle = styled(InputTitleComponent)`
-  width: 334px;
-  height: 31px;
-  margin-top: 1px;
+  .input-title {
+    width: 334px;
+    height: 31px;
+    margin-top: 1px;
+  }
 `;
 
 const MetricsGroupsHeader = styled.div`

--- a/ui/src/modules/Tokens/Comparation/Form/index.tsx
+++ b/ui/src/modules/Tokens/Comparation/Form/index.tsx
@@ -121,7 +121,7 @@ const FormToken = ({ mode, data }: Props) => {
       <FormProvider {...methods}>
         <Styled.Form onSubmit={handleSubmit(onSubmit)}>
           <ContentIcon icon="token">
-            <Form.InputTitle
+            <Styled.InputTitle
               name="name"
               placeholder="Type a name"
               ref={self => {

--- a/ui/src/modules/Tokens/Comparation/Form/styled.ts
+++ b/ui/src/modules/Tokens/Comparation/Form/styled.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import FormComponent from 'core/components/Form';
 import ButtonComponent from 'core/components/Button';
 import IconComponent from 'core/components/Icon';
@@ -27,6 +27,12 @@ const Title = styled(Text.h2)`
   > :last-child {
     margin-left: 10px;
   }
+`;
+
+const InputTitle = styled(FormComponent.InputTitle)`
+  ${({ resume }) => !resume && css`
+    margin-top: -4px;
+  `}
 `;
 
 const Info = styled.div`
@@ -64,6 +70,7 @@ const Icon = styled(IconComponent)`
 export default {
   Content,
   Title,
+  InputTitle,
   Info,
   Form,
   Input,


### PR DESCRIPTION
## Issue Description

_Ao criar um access token, no campo de digitar o nome, o placeholder do campo nao esta alinhado verticalmente_
by @luanecavalcantizup 

## Solution

- Adicionado margem para componente `<InputTitle />` da tela em questão.