### PR TITLE
Add responsiveness to change password modal

### DIFF
--- a/ui/src/modules/Account/index.tsx
+++ b/ui/src/modules/Account/index.tsx
@@ -79,9 +79,9 @@ const Account = () => {
 
   const renderModal = () =>
     toggleModal && (
-      <Modal.Default onClose={() => setToggleModal(false)}>
+      <Styled.Modal.Default onClose={() => setToggleModal(false)}>
         <ChangePassword onSubmit={() => setToggleModal(false)} />
-      </Modal.Default>
+      </Styled.Modal.Default>
     );
 
   const renderContent = () => (

--- a/ui/src/modules/Account/styled.ts
+++ b/ui/src/modules/Account/styled.ts
@@ -70,11 +70,13 @@ const Actions = styled.div`
 const Modal = styled(ComponentModal.Default)`
   .modal-container {
     max-height: 550px;
+    padding-right: 25px;
     bottom: 100px;
   }
 
   .modal-content {
     overflow-y: auto;
+    padding-right: 10px;
     max-height: 500px;
   }
 `;

--- a/ui/src/modules/Account/styled.ts
+++ b/ui/src/modules/Account/styled.ts
@@ -22,6 +22,7 @@ import Text from 'core/components/Text';
 import FormComponent from 'core/components/Form';
 import { slideInLeft, fadeIn } from 'core/assets/style/animate';
 import CheckPass from 'core/components/CheckPassword';
+import ComponentModal from 'core/components/Modal';
 
 const Wrapper = styled.div`
   animation: 0.2s ${slideInLeft} linear;
@@ -63,6 +64,18 @@ const Actions = styled.div`
 
   > :last-child {
     margin-left: 36px;
+  }
+`;
+
+const Modal = styled(ComponentModal.Default)`
+  .modal-container {
+    max-height: 550px;
+    bottom: 100px;
+  }
+
+  .modal-content {
+    overflow-y: auto;
+    max-height: 500px;
   }
 `;
 
@@ -116,6 +129,7 @@ export default {
   ChangePassword,
   Password,
   Modal: {
+    Default: Modal,
     Subtitle: ModalSubtitle,
     Info: ModalInfo
   },


### PR DESCRIPTION
## Issue Description

_Modal "change password" na resolução 1920x1080, não paresenta o botão save_
by @iezadamascenozup 

## Solution

Adicionado responsividade para o modal de change password

## Result
https://user-images.githubusercontent.com/69310124/117347918-ffc34900-ae7f-11eb-8081-4cfac572b4e6.mov





