### PR TITLE
Add validation isNotBlank for Workspaces' name on creation

### DIFF
--- a/ui/src/modules/Workspaces/index.tsx
+++ b/ui/src/modules/Workspaces/index.tsx
@@ -22,7 +22,7 @@ import { useSaveWorkspace } from 'modules/Workspaces/hooks';
 import { useHistory } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import routes from 'core/constants/routes';
-import { isRequired, maxLength } from 'core/utils/validations';
+import { isNotBlank, isRequired, maxLength } from 'core/utils/validations';
 import { removeWizard } from 'modules/Settings/helpers';
 import Modal from 'core/components/Modal';
 import Menu from './Menu';
@@ -76,6 +76,9 @@ const Workspaces = () => {
             error={errors?.name?.message}
             ref={register({
               required: isRequired(),
+              validate: {
+                notBlank: isNotBlank,
+              },
               maxLength: maxLength()
             })}
           />


### PR DESCRIPTION
## Issue Description

_Front permite criação com espaços vazios no nome do workspace, a regra de bloquear a criação de espaços vazios está ativa apenas no back_
by @iezadamascenozup 

## Solution

Adicionado validação no campo para prevenir criação de Workspaces apenas com espaços vazios.

## Results
https://user-images.githubusercontent.com/69310124/117348955-39e11a80-ae81-11eb-99e7-28a5e0d9ca0b.mov

