### PR TITLE
Fixing wrong method on policies csv

### DIFF
--- a/gate/resources/policy.csv
+++ b/gate/resources/policy.csv
@@ -34,7 +34,7 @@ p,public,/moove/webjars*,GET
 p,public,/moove/swagger-resources*,GET
 p,management,/moove/v2/users/{email:.+},GET
 p,management,/moove/v2/users/{id}/workspaces,GET
-p,management,/moove/v2/users/password,GET
+p,management,/moove/v2/users/password,PUT
 p,management,/moove/v2/users,GET
 p,management,/gate/api/v1/system-token*,(GET)|(POST)|(PUT)
 p,management,/moove/v2/workspaces*,POST


### PR DESCRIPTION
Signed-off-by: Mateus Cruz <emiteze@hotmail.com>

## Issue Description

User is receiving a 403 forbidden when trying to update its own password.

## Solution

Fixed wrong password method on gate policies.