### PR TITLE
Bug hunting/fix error cache

### DIFF
--- a/butler/src/app/v2/operator/logs-aggregator/kubernetes-events-aggregator.ts
+++ b/butler/src/app/v2/operator/logs-aggregator/kubernetes-events-aggregator.ts
@@ -16,7 +16,6 @@
 
 import * as k8s from '@kubernetes/client-node'
 import { Injectable } from '@nestjs/common'
-import * as http from 'http'
 import * as moment from 'moment'
 import { LogEntity } from '../../api/deployments/entity/logs.entity'
 import { ConsoleLoggerService } from '../../core/logs/console'

--- a/butler/src/app/v2/operator/logs-aggregator/kubernetes-events-aggregator.ts
+++ b/butler/src/app/v2/operator/logs-aggregator/kubernetes-events-aggregator.ts
@@ -27,7 +27,7 @@ import * as LRUCache from 'lru-cache'
 import { AppConstants } from '../../core/constants'
 import { plainToClass } from 'class-transformer'
 import { K8sManifestWithSpec } from '../../core/integrations/interfaces/k8s-manifest.interface'
-import {KubernetesObject} from "@kubernetes/client-node/dist/types";
+import { KubernetesObject } from '@kubernetes/client-node/dist/types'
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 @Injectable()
 export class EventsLogsAggregator {


### PR DESCRIPTION
Signed-off-by: thalles freitas <thalles.freitas@zup.com.br>

## Issue Description
Saving the cache of resources as promises gave the possibility to save rejected promises and with that resources that were available after a while always had the rejected promise in the cache, making it impossible to save the associated log.
## Solution
Save the resource instead of promises in cache
