### PR TITLE
Returning correct error when helm url is invalid

### DIFF
--- a/butler/src/app/v2/core/integrations/github/github-repository.ts
+++ b/butler/src/app/v2/core/integrations/github/github-repository.ts
@@ -106,7 +106,7 @@ export class GitHubRepository implements Repository {
     return fetchError.pipe(
       concatMap((error, attempts: number) => {
         return attempts >= AppConstants.FETCH_RESOURCE_MAXIMUM_RETRY_ATTEMPTS   ?
-          throwError(`Reached maximum fetch attempts! ${error}`) :
+          throwError(error) :
           of(error).pipe(
             tap(() => this.consoleLoggerService.log(`Fetch attempt #${attempts + 1}. Retrying fetch resource!`)),
             delay(AppConstants.FETCH_RESOURCE_MILLISECONDS_RETRY_DELAY)

--- a/butler/src/app/v2/core/integrations/gitlab/gitlab-repository.ts
+++ b/butler/src/app/v2/core/integrations/gitlab/gitlab-repository.ts
@@ -120,7 +120,7 @@ export class GitLabRepository implements Repository {
     return fetchError.pipe(
       concatMap((error, attempts: number) => {
         return attempts >= AppConstants.MOOVE_NOTIFICATION_MAXIMUM_RETRY_ATTEMPTS   ?
-          throwError(`Reached maximum fetch attempts! ${error}`) :
+          throwError(error) :
           of(error).pipe(
             tap(() => this.consoleLoggerService.log(`Fetch attempt #${attempts + 1}. Retrying fetch resource!`)),
             delay(AppConstants.MOOVE_NOTIFICATION_MILLISECONDS_RETRY_DELAY)

--- a/butler/src/tests/v2/unit/github/github-repository.spec.ts
+++ b/butler/src/tests/v2/unit/github/github-repository.spec.ts
@@ -101,7 +101,7 @@ describe('Download resources from github', () => {
     ).rejects.toMatchObject({
       response: {
         errors: [{
-          detail: `Status 'INTERNAL_SERVER_ERROR' with error: Reached maximum fetch attempts! ${errorMessage}`,
+          detail: `Status 'INTERNAL_SERVER_ERROR' with error: ${errorMessage}`,
           source: 'components.helmRepository',
           status: 500,
           title: 'Unable to fetch resource from github url: https://api.github.com/repos/charlescd-fake/helm-chart/contents/helm-chart?ref=master'

--- a/butler/src/tests/v2/unit/gitlab/gitlab-repository.spec.ts
+++ b/butler/src/tests/v2/unit/gitlab/gitlab-repository.spec.ts
@@ -103,7 +103,7 @@ describe('Download resources from gitlab', () => {
     ).rejects.toMatchObject({
       response: {
         errors: [{
-          detail: `Status 'INTERNAL_SERVER_ERROR' with error: Reached maximum fetch attempts! ${errorMessage}`,
+          detail: `Status 'INTERNAL_SERVER_ERROR' with error: ${errorMessage}`,
           source: 'components.helmRepository',
           status: 500,
           title: 'Unable to fetch resource from gitlab url: https://gitlab.com/api/v4/projects/22700476/repository/tree?ref=feature&path=helm-chart'


### PR DESCRIPTION
Fix:

[BACK] Quando helmUrl é inválido e tento fazer um deploy,  /moove/v2/deployments responde com erro 500