### PR TITLE
[BUG HUNT] Disable button on deploy

### DIFF
--- a/ui/src/modules/Circles/Release/Create/__tests__/CreateRelease.spec.tsx
+++ b/ui/src/modules/Circles/Release/Create/__tests__/CreateRelease.spec.tsx
@@ -173,11 +173,6 @@ test('should disable button on deploy', async () => {
   const versionInput = screen.getByTestId('input-text-modules[0].version');
   await act(async () => userEvent.type(versionInput, 'image-1.0.0'));
 
-  await waitFor(() =>
-    expect(screen.getByTestId('button-default-submit')).not.toBeDisabled(),
-    { timeout: 700 }
-  );
-
   await act(async () => userEvent.click(screen.getByTestId('button-default-submit')));
 
   expect(screen.getByTestId('button-default-submit')).toBeDisabled();

--- a/ui/src/modules/Circles/Release/Create/__tests__/CreateRelease.spec.tsx
+++ b/ui/src/modules/Circles/Release/Create/__tests__/CreateRelease.spec.tsx
@@ -150,3 +150,35 @@ test('form should be invalid when version name not found', async () => {
 
   expect(submit).toBeDisabled();
 });
+
+test('should disable button on deploy', async () => {
+  (fetch as FetchMock)
+    .mockResponseOnce(mockGetModules)
+    .mockResponseOnce(mockGetTags1)
+    .mockResponse(JSON.stringify([]));
+
+  render(
+    <CreateRelease circleId="123" onDeployed={() => { }} />
+  );
+
+  const nameInput = screen.getByTestId('input-text-releaseName');
+  await act(async () => userEvent.type(nameInput, 'release-name'));
+
+  const moduleLabel = screen.getByText('Select a module');
+  await act(async () => selectEvent.select(moduleLabel, 'module-1'));
+
+  const componentLabel = screen.getByText('Select a component');
+  await act(async () => selectEvent.select(componentLabel, 'component-1'));
+
+  const versionInput = screen.getByTestId('input-text-modules[0].version');
+  await act(async () => userEvent.type(versionInput, 'image-1.0.0'));
+
+  await waitFor(() =>
+    expect(screen.getByTestId('button-default-submit')).not.toBeDisabled(),
+    { timeout: 700 }
+  );
+
+  await act(async () => userEvent.click(screen.getByTestId('button-default-submit')));
+
+  expect(screen.getByTestId('button-default-submit')).toBeDisabled();
+});

--- a/ui/src/modules/Circles/Release/Create/index.tsx
+++ b/ui/src/modules/Circles/Release/Create/index.tsx
@@ -60,6 +60,7 @@ const CreateRelease = ({ circleId, onDeployed }: Props) => {
   });
   const isNotUnique = fields.length > ONE;
   const [error, setError] = useState('');
+  const [isDeploying, setIsDeploying] = useState(false);
 
   useEffect(() => {
     if (watchFields) {
@@ -84,6 +85,7 @@ const CreateRelease = ({ circleId, onDeployed }: Props) => {
   }, [createDeployment, build, circleId]);
 
   const onSubmit = () => {
+    setIsDeploying(true);
     const data = getValues();
     const modules = formatDataModules(data);
 
@@ -143,7 +145,7 @@ const CreateRelease = ({ circleId, onDeployed }: Props) => {
           type="submit"
           size="EXTRA_SMALL"
           isLoading={savingBuild}
-          isDisabled={isEmptyFields || !isEmpty(errors) || !isEmpty(error)}
+          isDisabled={isEmptyFields || !isEmpty(errors) || !isEmpty(error) || isDeploying}
         >
           Deploy
         </Styled.Submit>


### PR DESCRIPTION
Disable `Deploy` button on deploy, so a user cannot make same request twice.