### PR TITLE
Change logs Set to List to garantee order

### DIFF
--- a/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/FindDeploymentLogsInteractorTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/FindDeploymentLogsInteractorTest.groovy
@@ -57,7 +57,7 @@ class FindDeploymentLogsInteractorTest extends Specification {
         def deploymentConfiguration = TestUtils.deploymentConfig
         def log = new Log("INFO", "log title", "log details", LocalDateTime.now().toString())
         def logResponse = new LogResponse(
-                [log] as Set
+                [log]
         )
 
         when:
@@ -84,7 +84,7 @@ class FindDeploymentLogsInteractorTest extends Specification {
         def deploymentId = '083337ef-6177-4a24-b32e-f7429336ec20'
         def log = new Log("INFO", "log title", "log details", LocalDateTime.now().toString())
         def logResponse = new LogResponse(
-                [log]  as Set
+                [log]
         )
         def deploymentConfiguration = TestUtils.deploymentConfig
 

--- a/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/LogResponse.kt
+++ b/moove/infrastructure/src/main/kotlin/io/charlescd/moove/infrastructure/service/client/response/LogResponse.kt
@@ -17,7 +17,7 @@
 package io.charlescd.moove.infrastructure.service.client.response
 
 data class LogResponse(
-    val logs: Set<Log>
+    val logs: List<Log>
 )
 
 data class Log(


### PR DESCRIPTION
Butler sends back to moove the logs list sorted by date. But moove is managing the logs using a Set (the has no order garanted). Changing to List