### PR TITLE
adding deployment active on patch workspace to remove deployment config

### DIFF
--- a/moove/api/src/main/kotlin/io/charlescd/moove/api/MooveExceptionHandler.kt
+++ b/moove/api/src/main/kotlin/io/charlescd/moove/api/MooveExceptionHandler.kt
@@ -151,9 +151,7 @@ class MooveExceptionHandler(private val messageSource: MessageSource) {
     fun businessException(ex: BusinessException): ErrorMessageResponse {
         this.logger.error(ex.message, ex)
         return ErrorMessageResponse.of(ex.getErrorCode(),
-            ex.getParameters()
-                ?.let { messageSource.getMessage(ex.getErrorCode().key, ex.getParameters(), Locale.ENGLISH) }
-                ?: ex.message)
+             messageSource.getMessage(ex.getErrorCode().key, ex.getParameters(), Locale.ENGLISH))
     }
 
     @ExceptionHandler(ForbiddenException::class)

--- a/moove/api/src/main/kotlin/io/charlescd/moove/api/MooveExceptionHandler.kt
+++ b/moove/api/src/main/kotlin/io/charlescd/moove/api/MooveExceptionHandler.kt
@@ -151,7 +151,7 @@ class MooveExceptionHandler(private val messageSource: MessageSource) {
     fun businessException(ex: BusinessException): ErrorMessageResponse {
         this.logger.error(ex.message, ex)
         return ErrorMessageResponse.of(ex.getErrorCode(),
-             messageSource.getMessage(ex.getErrorCode().key, ex.getParameters(), Locale.ENGLISH))
+            messageSource.getMessage(ex.getErrorCode().key, ex.getParameters(), Locale.ENGLISH))
     }
 
     @ExceptionHandler(ForbiddenException::class)

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
@@ -143,7 +143,8 @@ open class PatchWorkspaceInteractorImpl(
     }
 
     private fun isDeploymentConfigurationDelete(patch: PatchOperation): Boolean {
-        return patch.op == OpCodeEnum.REMOVE && patch.path == DEPLOYMENT_CONFIGURATION_PATH
+        return (patch.op == OpCodeEnum.REMOVE || patch.op == OpCodeEnum.REPLACE) 
+                && patch.path == DEPLOYMENT_CONFIGURATION_PATH
     }
 
     private fun hasActiveDeploymentInWorkspace(workspaceId: String): Boolean {

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
@@ -136,7 +136,7 @@ open class PatchWorkspaceInteractorImpl(
 
     private fun checkIfDeploymentDeploymentConfigurationCanBeUpdated(workspaceId: String, patches: List<PatchOperation>) {
         patches.forEach { patch ->
-            if(isDeploymentConfigurationDelete(patch) && hasActiveDeploymentInWorkspace(workspaceId)) {
+            if (isDeploymentConfigurationDelete(patch) && hasActiveDeploymentInWorkspace(workspaceId)) {
                 throw BusinessException.of(MooveErrorCode.ACTIVE_DEPLOYMENT_NAMESPACE_ERROR)
             }
         }

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
@@ -143,8 +143,8 @@ open class PatchWorkspaceInteractorImpl(
     }
 
     private fun isDeploymentConfigurationDelete(patch: PatchOperation): Boolean {
-        return (patch.op == OpCodeEnum.REMOVE || patch.op == OpCodeEnum.REPLACE) 
-                && patch.path == DEPLOYMENT_CONFIGURATION_PATH
+        return (patch.op == OpCodeEnum.REMOVE || patch.op == OpCodeEnum.REPLACE) &&
+                patch.path == DEPLOYMENT_CONFIGURATION_PATH
     }
 
     private fun hasActiveDeploymentInWorkspace(workspaceId: String): Boolean {

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/workspace/impl/PatchWorkspaceInteractorImpl.kt
@@ -50,7 +50,7 @@ open class PatchWorkspaceInteractorImpl(
 
         val workspace = workspaceService.find(workspaceId)
 
-        checkIfDeploymentDeploymentConfigurationCanBeUpdated(workspaceId, request.patches)
+        checkIfDeploymentConfigurationCanBeUpdated(workspaceId, request.patches)
 
         val updatedWorkspace = request.applyPatch(workspace)
 
@@ -134,7 +134,7 @@ open class PatchWorkspaceInteractorImpl(
         return configuration != updatedInformation && updatedInformation != null
     }
 
-    private fun checkIfDeploymentDeploymentConfigurationCanBeUpdated(workspaceId: String, patches: List<PatchOperation>) {
+    private fun checkIfDeploymentConfigurationCanBeUpdated(workspaceId: String, patches: List<PatchOperation>) {
         patches.forEach { patch ->
             if (isDeploymentConfigurationDelete(patch) && hasActiveDeploymentInWorkspace(workspaceId)) {
                 throw BusinessException.of(MooveErrorCode.ACTIVE_DEPLOYMENT_NAMESPACE_ERROR)


### PR DESCRIPTION
Signed-off-by: barbararochazup <barbara.rocha@zup.com.br>

## Issue Description

Adding validation to patch workspace when remove a configuration id to not remove when have a active deployment