### PR TITLE
Enabling gate configurations at values.yaml.

### DIFF
--- a/install/helm-chart/values.yaml
+++ b/install/helm-chart/values.yaml
@@ -339,7 +339,7 @@ CharlesApplications:
     subscriptionRegisterLimit: 5
 
   gate:
-    enabled: false
+    enabled: true
     name: charlescd-gate
     sidecarIstio:
       enabled: true
@@ -512,7 +512,7 @@ envoy:
   hermes:
     enabled: true
   gate:
-    enabled: false
+    enabled: true
   cors:
     enabled: true
     hosts: []


### PR DESCRIPTION
## Issue Description

Without enabling gate, users won't be able to create access tokens.
