### PR TITLE
Update moove pom.xml - Keycloak Admin Client 13.0.0 and Jboss RestEAS…

### DIFF
--- a/moove/pom.xml
+++ b/moove/pom.xml
@@ -34,7 +34,7 @@
         <kotlin.version>1.3.41</kotlin.version>
         <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
         <charlescd.tracing.version>1.0</charlescd.tracing.version>
-        <jboss.resteasy.version>4.5.7.Final</jboss.resteasy.version>
+        <jboss.resteasy.version>3.1.4.Final</jboss.resteasy.version>
         <snakeyaml.version>1.25</snakeyaml.version>
         <keycloak.version>13.0.0</keycloak.version>
         <csv.validator.version>1.1</csv.validator.version>
@@ -48,7 +48,7 @@
         <eclipse.egit.github.core.version>2.1.5</eclipse.egit.github.core.version>
         <feign.jackson.version>9.5.1</feign.jackson.version>
         <modelmapper.version>2.3.0</modelmapper.version>
-        <keycloak.admin.client.version>7.0.1</keycloak.admin.client.version>
+        <keycloak.admin.client.version>13.0.0</keycloak.admin.client.version>
         <cglib.nodep.version>3.3.0</cglib.nodep.version>
         <hibernate.types.version>2.5.0</hibernate.types.version>
         <spring.jdbc.version>5.2.4.RELEASE</spring.jdbc.version>


### PR DESCRIPTION
…Y 3.1.4.FINAL

Signed-off-by: Felipe Brunelli de Andrade <felipe.andrade@zup.com.br>

Need to upgrade Keycloak version to 13.0.0 and rollback in Jboss RestEASY Client version to 3.1.4.FINAL