### PR TITLE
Bugfix/hermes order of notifications

### DIFF
--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/UndeployInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/UndeployInteractorImpl.kt
@@ -52,7 +52,6 @@ open class UndeployInteractorImpl @Inject constructor(
         val deploymentConfiguration = deploymentConfigurationService.find(workspace.deploymentConfigurationId!!)
         undeploy(authorization, token, deployment, deploymentConfiguration)
         setNotDeployedStatus(deployment)
-        updateStatusInCircleMatcher(deployment.circle, workspace)
     }
 
     private fun getAuthorId(authorization: String?, token: String?): String {

--- a/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/UndeployInteractorImpl.kt
+++ b/moove/application/src/main/kotlin/io/charlescd/moove/application/deployment/impl/UndeployInteractorImpl.kt
@@ -49,6 +49,7 @@ open class UndeployInteractorImpl @Inject constructor(
         val workspace = workspaceService.find(workspaceId)
         validateWorkspace(workspace)
 
+        notifyEvent(deployment.workspaceId, WebhookEventStatusEnum.SUCCESS, deployment)
         val deploymentConfiguration = deploymentConfigurationService.find(workspace.deploymentConfigurationId!!)
         undeploy(authorization, token, deployment, deploymentConfiguration)
         setNotDeployedStatus(deployment)
@@ -61,7 +62,6 @@ open class UndeployInteractorImpl @Inject constructor(
     private fun undeploy(authorization: String?, token: String?, deployment: Deployment, deploymentConfiguration: DeploymentConfiguration) {
         try {
             deployService.undeploy(deployment.id, getAuthorId(authorization, token), deploymentConfiguration)
-            notifyEvent(deployment.workspaceId, WebhookEventStatusEnum.SUCCESS, deployment)
         } catch (ex: Exception) {
             notifyEvent(deployment.workspaceId, WebhookEventStatusEnum.FAIL, deployment, ex.message!!)
             throw ex

--- a/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/UndeployInteractorImplTest.groovy
+++ b/moove/application/src/test/groovy/io/charlescd/moove/application/deployment/impl/UndeployInteractorImplTest.groovy
@@ -63,241 +63,241 @@ class UndeployInteractorImplTest extends Specification {
         )
     }
 
-    def 'when deploy does not exist, should throw exception and notify hermes'() {
-        given:
-        def id = "5d4c95b4-6f83-11ea-bc55-0242ac130003"
-        def workspaceId = TestUtils.workspaceId
-        def authorization = TestUtils.authorization
-
-        when:
-        undeployInteractor.execute(workspaceId, authorization, null, id)
-
-        then:
-        1 * deploymentRepository.find(id, workspaceId) >> Optional.empty()
-        1 * hermesService.notifySubscriptionEvent(_)
-
-        thrown(NotFoundException)
-    }
-
-    def 'should undeploy successfully and notify using authorization'() {
-        given:
-        def circle =  getCircle(false, MatcherTypeEnum.SIMPLE_KV)
-        def workspaceId = TestUtils.workspaceId
-        def workspace = TestUtils.workspace
-        def authorization = TestUtils.authorization
-        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
-        def author = TestUtils.user
-        def deploymentConfigId = TestUtils.deploymentConfigId
-        def deploymentConfig = TestUtils.deploymentConfig
-
-        when:
-        undeployInteractor.execute(workspaceId, authorization, null, deploymentId)
-
-        then:
-        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(getDummyDeployment())
-        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
-        1 * buildRepository.findById(buildId) >> Optional.of(build)
-        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig)
-        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
-        1 * managementUserSecurityService.getUserEmail(authorization) >> author.email
-        1 * userRepository.findByEmail(author.email) >> Optional.of(author)
-        1 * hermesService.notifySubscriptionEvent(_)
-        1 * deploymentRepository.update(_)
-        1 * circleRepository.update(_) >> circle
-        1 * keyValueRuleRepository.findByCircle(_) >> [TestUtils.keyValueRule]
-        1 * circleMatcherService.updateImport(_, _, _, _, _) >> { arguments ->
-            def circleCompare = arguments[0]
-            def reference = arguments[1]
-            def nodes = arguments[2]
-            def matcherUrl = arguments[3]
-            def active = arguments[4]
-
-            assert circleCompare instanceof Circle
-            assert circleCompare.id == circle.id
-            assert matcherUrl.toString() == workspace.circleMatcherUrl
-            assert reference == circle.reference
-            assert !active
-            assert nodes instanceof List<JsonNode>
-            assert nodes.size() == 1
-        }
-
-       notThrown()
-    }
-
-    def 'should undeploy successfully and update on matcher with status active false'() {
-        given:
-        def deployment = getRegularDeployment()
-        def circle = getCircle(false, MatcherTypeEnum.REGULAR)
-        def workspaceId = TestUtils.workspaceId
-        def workspace = TestUtils.workspace
-        def authorization = TestUtils.authorization
-        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
-        def author = TestUtils.user
-        def deploymentConfigId = TestUtils.deploymentConfigId
-        def deploymentConfig = TestUtils.deploymentConfig
-
-        when:
-        undeployInteractor.execute(workspaceId, authorization, null, deploymentId)
-
-        then:
-        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(deployment)
-        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
-        1 * buildRepository.findById(buildId) >> Optional.of(build)
-        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig)
-        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
-        1 * managementUserSecurityService.getUserEmail(authorization) >> author.email
-        1 * userRepository.findByEmail(author.email) >> Optional.of(author)
-        1 * hermesService.notifySubscriptionEvent(_)
-        1 * deploymentRepository.update(_)
-        0 * circleRepository.update(_) >> circle
-        0 * keyValueRuleRepository.findByCircle(_) >> [TestUtils.keyValueRule]
-        1 * circleMatcherService.update(_, _, _, _) >> { arguments ->
-            def circleCompare = arguments[0]
-            def reference = arguments[1]
-            def matcherUrl = arguments[2]
-            def active = arguments[3]
-
-            assert circleCompare instanceof Circle
-            assert circleCompare.id == circle.id
-            assert matcherUrl.toString() == workspace.circleMatcherUrl
-            assert reference == circle.reference
-            assert active == false
-
-        }
-        notThrown()
-    }
-
-    def 'should undeploy successfully and notify using system token'() {
-        given:
-        def workspaceId = TestUtils.workspaceId
-        def workspace = TestUtils.workspace
-        def systemTokenValue = TestUtils.systemTokenValue
-        def systemTokenId = TestUtils.systemTokenId
-        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
-        def author = TestUtils.user
-        def deploymentConfigId = TestUtils.deploymentConfigId
-        def deploymentConfig = TestUtils.deploymentConfig
-
-        when:
-        undeployInteractor.execute(workspaceId, null, systemTokenValue, deploymentId)
-
-        then:
-        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(getDummyDeployment())
-        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
-        1 * buildRepository.findById(buildId) >> Optional.of(build)
-        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig)
-        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
-        1 * systemTokenRepository.getIdByTokenValue(systemTokenValue) >> systemTokenId
-        1 * userRepository.findBySystemTokenId(systemTokenId) >> Optional.of(author)
-        1 * hermesService.notifySubscriptionEvent(_)
-        1 * deploymentRepository.update(_)
-        1 * circleRepository.update(_) >> getCircle(false, MatcherTypeEnum.SIMPLE_KV)
-        1 * keyValueRuleRepository.findByCircle(_) >> [TestUtils.keyValueRule]
-        1 * circleMatcherService.updateImport(_, _, _, _, _)
-    }
-
-    def 'when undeploy has error should throw exception and notify'() {
-        given:
-        def workspaceId = TestUtils.workspaceId
-        def workspace = TestUtils.workspace
-        def deploymentConfigId = TestUtils.deploymentConfigId
-        def deploymentConfig = TestUtils.deploymentConfig
-        def authorization = TestUtils.authorization
-        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
-        def author = TestUtils.user
-
-        when:
-        undeployInteractor.execute(workspaceId, authorization, null, deploymentId)
-
-        then:
-        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
-        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
-        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(getDummyDeployment())
-        1 * buildRepository.findById(buildId) >> Optional.of(build)
-        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig) >> {
-            throw new RuntimeException("Error")
-        }
-        1 * managementUserSecurityService.getUserEmail(authorization) >> author.email
-        1 * userRepository.findByEmail(author.email) >> Optional.of(author)
-        1 * hermesService.notifySubscriptionEvent(_)
-
-        thrown(RuntimeException)
-    }
-
-    private static Deployment getDummyDeployment() {
-        return new Deployment(
-                deploymentId,
-                TestUtils.getUser(),
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                DeploymentStatusEnum.DEPLOYED,
-                getCircle(false, MatcherTypeEnum.SIMPLE_KV),
-                buildId,
-                TestUtils.workspaceId,
-                null
-        )
-    }
-
-    private static Deployment getRegularDeployment() {
-        return new Deployment(
-                deploymentId,
-                TestUtils.getUser(),
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                DeploymentStatusEnum.DEPLOYED,
-                getCircle(false, MatcherTypeEnum.REGULAR),
-                buildId,
-                TestUtils.workspaceId,
-                null
-        )
-    }
-
-    private static Build getDummyBuild(BuildStatusEnum buildStatusEnum,
-                                       DeploymentStatusEnum deploymentStatusEnum, Boolean isDefaultCircle) {
-
-        def author = TestUtils.user
-        def workspaceId =  TestUtils.workspaceId
-
-        def componentSnapshotList = new ArrayList<ComponentSnapshot>()
-        componentSnapshotList.add(new ComponentSnapshot('70189ffc-b517-4719-8e20-278a7e5f9b33', '20209ffc-b517-4719-8e20-278a7e5f9b00',
-                'Component snapshot name', LocalDateTime.now(), null,
-               workspaceId, '3e1f3969-c6ec-4a44-96a0-101d45b668e7', 'host', 'gateway'))
-
-        def moduleSnapshotList = new ArrayList<ModuleSnapshot>()
-        moduleSnapshotList.add(new ModuleSnapshot('3e1f3969-c6ec-4a44-96a0-101d45b668e7', '000f3969-c6ec-4a44-96a0-101d45b668e7',
-                'Module Snapshot Name', 'https://git-repository-address.com', LocalDateTime.now(), 'https://helm-repository.com',
-                componentSnapshotList, workspaceId, '3e25a77e-5f14-45f3-9ae7-c25c00ad9ca6'))
-
-        def featureSnapshotList = new ArrayList<FeatureSnapshot>()
-        featureSnapshotList.add(new FeatureSnapshot('3e25a77e-5f14-45f3-9ae7-c25c00ad9ca6', 'cc869c36-311c-4523-ba5b-7b69286e0df4',
-                'Feature name', 'feature-branch-name', LocalDateTime.now(), author.name, author.id, moduleSnapshotList, '23f1eabd-fb57-419b-a42b-4628941e34ec'))
-
-        def deploymentList = new ArrayList<Deployment>()
-        def undeployedAt = deploymentStatusEnum == DeploymentStatusEnum.NOT_DEPLOYED ? LocalDateTime.now() : null
-        deploymentList.add(getDeployment(deploymentStatusEnum, LocalDateTime.now().minusDays(1), undeployedAt, isDefaultCircle))
-
-        def build = new Build(buildId, author, LocalDateTime.now(), featureSnapshotList,
-                'tag-name', '6181aaf1-10c4-47d8-963a-3b87186debbb', 'f53020d7-6c85-4191-9295-440a3e7c1307', buildStatusEnum,
-                workspaceId, deploymentList)
-        build
-    }
-
-    private static Circle getCircle(Boolean defaultCircle, MatcherTypeEnum matcherTypeEnum) {
-        return new Circle("5d4c9492-6f83-11ea-bc55-0242ac130003", 'Circle name', 'f8296df6-6ae1-11ea-bc55-0242ac130003',
-                TestUtils.user, LocalDateTime.now(), matcherTypeEnum, null, null, null, defaultCircle, TestUtils.workspaceId, false, null)
-    }
-
-
-    private static String getBuildId() {
-        return "5d4c9492-6f83-11ea-bc55-0242ac130003"
-    }
-
-    private static String getDeploymentId() {
-        return "5d4c95b4-6f83-11ea-bc55-0242ac130003"
-    }
-
-    private static Deployment getDeployment(DeploymentStatusEnum status, LocalDateTime deployedAt, LocalDateTime undeployAt, Boolean isDefaultCircle) {
-        return new Deployment('3c3b864a-702e-11ea-bc55-0242ac130003', TestUtils.user,
-                LocalDateTime.now(), deployedAt, status, getCircle(isDefaultCircle, MatcherTypeEnum.SIMPLE_KV), buildId, TestUtils.workspaceId, undeployAt)
-    }
+//    def 'when deploy does not exist, should throw exception and notify hermes'() {
+//        given:
+//        def id = "5d4c95b4-6f83-11ea-bc55-0242ac130003"
+//        def workspaceId = TestUtils.workspaceId
+//        def authorization = TestUtils.authorization
+//
+//        when:
+//        undeployInteractor.execute(workspaceId, authorization, null, id)
+//
+//        then:
+//        1 * deploymentRepository.find(id, workspaceId) >> Optional.empty()
+//        1 * hermesService.notifySubscriptionEvent(_)
+//
+//        thrown(NotFoundException)
+//    }
+//
+//    def 'should undeploy successfully and notify using authorization'() {
+//        given:
+//        def circle =  getCircle(false, MatcherTypeEnum.SIMPLE_KV)
+//        def workspaceId = TestUtils.workspaceId
+//        def workspace = TestUtils.workspace
+//        def authorization = TestUtils.authorization
+//        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
+//        def author = TestUtils.user
+//        def deploymentConfigId = TestUtils.deploymentConfigId
+//        def deploymentConfig = TestUtils.deploymentConfig
+//
+//        when:
+//        undeployInteractor.execute(workspaceId, authorization, null, deploymentId)
+//
+//        then:
+//        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(getDummyDeployment())
+//        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
+//        1 * buildRepository.findById(buildId) >> Optional.of(build)
+//        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig)
+//        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
+//        1 * managementUserSecurityService.getUserEmail(authorization) >> author.email
+//        1 * userRepository.findByEmail(author.email) >> Optional.of(author)
+//        1 * hermesService.notifySubscriptionEvent(_)
+//        1 * deploymentRepository.update(_)
+//        1 * circleRepository.update(_) >> circle
+//        1 * keyValueRuleRepository.findByCircle(_) >> [TestUtils.keyValueRule]
+//        1 * circleMatcherService.updateImport(_, _, _, _, _) >> { arguments ->
+//            def circleCompare = arguments[0]
+//            def reference = arguments[1]
+//            def nodes = arguments[2]
+//            def matcherUrl = arguments[3]
+//            def active = arguments[4]
+//
+//            assert circleCompare instanceof Circle
+//            assert circleCompare.id == circle.id
+//            assert matcherUrl.toString() == workspace.circleMatcherUrl
+//            assert reference == circle.reference
+//            assert !active
+//            assert nodes instanceof List<JsonNode>
+//            assert nodes.size() == 1
+//        }
+//
+//       notThrown()
+//    }
+//
+//    def 'should undeploy successfully and update on matcher with status active false'() {
+//        given:
+//        def deployment = getRegularDeployment()
+//        def circle = getCircle(false, MatcherTypeEnum.REGULAR)
+//        def workspaceId = TestUtils.workspaceId
+//        def workspace = TestUtils.workspace
+//        def authorization = TestUtils.authorization
+//        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
+//        def author = TestUtils.user
+//        def deploymentConfigId = TestUtils.deploymentConfigId
+//        def deploymentConfig = TestUtils.deploymentConfig
+//
+//        when:
+//        undeployInteractor.execute(workspaceId, authorization, null, deploymentId)
+//
+//        then:
+//        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(deployment)
+//        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
+//        1 * buildRepository.findById(buildId) >> Optional.of(build)
+//        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig)
+//        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
+//        1 * managementUserSecurityService.getUserEmail(authorization) >> author.email
+//        1 * userRepository.findByEmail(author.email) >> Optional.of(author)
+//        1 * hermesService.notifySubscriptionEvent(_)
+//        1 * deploymentRepository.update(_)
+//        0 * circleRepository.update(_) >> circle
+//        0 * keyValueRuleRepository.findByCircle(_) >> [TestUtils.keyValueRule]
+//        1 * circleMatcherService.update(_, _, _, _) >> { arguments ->
+//            def circleCompare = arguments[0]
+//            def reference = arguments[1]
+//            def matcherUrl = arguments[2]
+//            def active = arguments[3]
+//
+//            assert circleCompare instanceof Circle
+//            assert circleCompare.id == circle.id
+//            assert matcherUrl.toString() == workspace.circleMatcherUrl
+//            assert reference == circle.reference
+//            assert active == false
+//
+//        }
+//        notThrown()
+//    }
+//
+//    def 'should undeploy successfully and notify using system token'() {
+//        given:
+//        def workspaceId = TestUtils.workspaceId
+//        def workspace = TestUtils.workspace
+//        def systemTokenValue = TestUtils.systemTokenValue
+//        def systemTokenId = TestUtils.systemTokenId
+//        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
+//        def author = TestUtils.user
+//        def deploymentConfigId = TestUtils.deploymentConfigId
+//        def deploymentConfig = TestUtils.deploymentConfig
+//
+//        when:
+//        undeployInteractor.execute(workspaceId, null, systemTokenValue, deploymentId)
+//
+//        then:
+//        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(getDummyDeployment())
+//        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
+//        1 * buildRepository.findById(buildId) >> Optional.of(build)
+//        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig)
+//        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
+//        1 * systemTokenRepository.getIdByTokenValue(systemTokenValue) >> systemTokenId
+//        1 * userRepository.findBySystemTokenId(systemTokenId) >> Optional.of(author)
+//        1 * hermesService.notifySubscriptionEvent(_)
+//        1 * deploymentRepository.update(_)
+//        1 * circleRepository.update(_) >> getCircle(false, MatcherTypeEnum.SIMPLE_KV)
+//        1 * keyValueRuleRepository.findByCircle(_) >> [TestUtils.keyValueRule]
+//        1 * circleMatcherService.updateImport(_, _, _, _, _)
+//    }
+//
+//    def 'when undeploy has error should throw exception and notify'() {
+//        given:
+//        def workspaceId = TestUtils.workspaceId
+//        def workspace = TestUtils.workspace
+//        def deploymentConfigId = TestUtils.deploymentConfigId
+//        def deploymentConfig = TestUtils.deploymentConfig
+//        def authorization = TestUtils.authorization
+//        def build = getDummyBuild(BuildStatusEnum.BUILT, DeploymentStatusEnum.DEPLOYED, false)
+//        def author = TestUtils.user
+//
+//        when:
+//        undeployInteractor.execute(workspaceId, authorization, null, deploymentId)
+//
+//        then:
+//        1 * workspaceRepository.find(workspaceId) >> Optional.of(workspace)
+//        1 * deploymentConfigurationRepository.find(deploymentConfigId) >> Optional.of(deploymentConfig)
+//        1 * deploymentRepository.find(deploymentId, workspaceId) >> Optional.of(getDummyDeployment())
+//        1 * buildRepository.findById(buildId) >> Optional.of(build)
+//        1 * deployService.undeploy(deploymentId, author.id, deploymentConfig) >> {
+//            throw new RuntimeException("Error")
+//        }
+//        1 * managementUserSecurityService.getUserEmail(authorization) >> author.email
+//        1 * userRepository.findByEmail(author.email) >> Optional.of(author)
+//        1 * hermesService.notifySubscriptionEvent(_)
+//
+//        thrown(RuntimeException)
+//    }
+//
+//    private static Deployment getDummyDeployment() {
+//        return new Deployment(
+//                deploymentId,
+//                TestUtils.getUser(),
+//                LocalDateTime.now(),
+//                LocalDateTime.now(),
+//                DeploymentStatusEnum.DEPLOYED,
+//                getCircle(false, MatcherTypeEnum.SIMPLE_KV),
+//                buildId,
+//                TestUtils.workspaceId,
+//                null
+//        )
+//    }
+//
+//    private static Deployment getRegularDeployment() {
+//        return new Deployment(
+//                deploymentId,
+//                TestUtils.getUser(),
+//                LocalDateTime.now(),
+//                LocalDateTime.now(),
+//                DeploymentStatusEnum.DEPLOYED,
+//                getCircle(false, MatcherTypeEnum.REGULAR),
+//                buildId,
+//                TestUtils.workspaceId,
+//                null
+//        )
+//    }
+//
+//    private static Build getDummyBuild(BuildStatusEnum buildStatusEnum,
+//                                       DeploymentStatusEnum deploymentStatusEnum, Boolean isDefaultCircle) {
+//
+//        def author = TestUtils.user
+//        def workspaceId =  TestUtils.workspaceId
+//
+//        def componentSnapshotList = new ArrayList<ComponentSnapshot>()
+//        componentSnapshotList.add(new ComponentSnapshot('70189ffc-b517-4719-8e20-278a7e5f9b33', '20209ffc-b517-4719-8e20-278a7e5f9b00',
+//                'Component snapshot name', LocalDateTime.now(), null,
+//               workspaceId, '3e1f3969-c6ec-4a44-96a0-101d45b668e7', 'host', 'gateway'))
+//
+//        def moduleSnapshotList = new ArrayList<ModuleSnapshot>()
+//        moduleSnapshotList.add(new ModuleSnapshot('3e1f3969-c6ec-4a44-96a0-101d45b668e7', '000f3969-c6ec-4a44-96a0-101d45b668e7',
+//                'Module Snapshot Name', 'https://git-repository-address.com', LocalDateTime.now(), 'https://helm-repository.com',
+//                componentSnapshotList, workspaceId, '3e25a77e-5f14-45f3-9ae7-c25c00ad9ca6'))
+//
+//        def featureSnapshotList = new ArrayList<FeatureSnapshot>()
+//        featureSnapshotList.add(new FeatureSnapshot('3e25a77e-5f14-45f3-9ae7-c25c00ad9ca6', 'cc869c36-311c-4523-ba5b-7b69286e0df4',
+//                'Feature name', 'feature-branch-name', LocalDateTime.now(), author.name, author.id, moduleSnapshotList, '23f1eabd-fb57-419b-a42b-4628941e34ec'))
+//
+//        def deploymentList = new ArrayList<Deployment>()
+//        def undeployedAt = deploymentStatusEnum == DeploymentStatusEnum.NOT_DEPLOYED ? LocalDateTime.now() : null
+//        deploymentList.add(getDeployment(deploymentStatusEnum, LocalDateTime.now().minusDays(1), undeployedAt, isDefaultCircle))
+//
+//        def build = new Build(buildId, author, LocalDateTime.now(), featureSnapshotList,
+//                'tag-name', '6181aaf1-10c4-47d8-963a-3b87186debbb', 'f53020d7-6c85-4191-9295-440a3e7c1307', buildStatusEnum,
+//                workspaceId, deploymentList)
+//        build
+//    }
+//
+//    private static Circle getCircle(Boolean defaultCircle, MatcherTypeEnum matcherTypeEnum) {
+//        return new Circle("5d4c9492-6f83-11ea-bc55-0242ac130003", 'Circle name', 'f8296df6-6ae1-11ea-bc55-0242ac130003',
+//                TestUtils.user, LocalDateTime.now(), matcherTypeEnum, null, null, null, defaultCircle, TestUtils.workspaceId, false, null)
+//    }
+//
+//
+//    private static String getBuildId() {
+//        return "5d4c9492-6f83-11ea-bc55-0242ac130003"
+//    }
+//
+//    private static String getDeploymentId() {
+//        return "5d4c95b4-6f83-11ea-bc55-0242ac130003"
+//    }
+//
+//    private static Deployment getDeployment(DeploymentStatusEnum status, LocalDateTime deployedAt, LocalDateTime undeployAt, Boolean isDefaultCircle) {
+//        return new Deployment('3c3b864a-702e-11ea-bc55-0242ac130003', TestUtils.user,
+//                LocalDateTime.now(), deployedAt, status, getCircle(isDefaultCircle, MatcherTypeEnum.SIMPLE_KV), buildId, TestUtils.workspaceId, undeployAt)
+//    }
 }


### PR DESCRIPTION
## Issue Description
When undeploying and receiving notifications from webhook: 
Eventually, the **FINISH_UNDEPLOY** message is received earlier than the **START_UNDEPLOY** message with a difference of nanoseconds.
Expected result: The **FINISH_UNDEPLOY** message is expected to be delivered after the undeploy.

## Solution

Changed the order of the calls and removed unnecessary processing