### PR TITLE
fix button disable

### DIFF
--- a/ui/src/modules/Circles/Comparation/Item/Layer/MetricsGroups.tsx
+++ b/ui/src/modules/Circles/Comparation/Item/Layer/MetricsGroups.tsx
@@ -46,13 +46,12 @@ const LayerMetricsGroups = ({ onClickCreate, circleId, circle }: Props) => {
   }, [getMetricsgroupsResume, circleId, status]);
 
   const renderAddMetricsGroups = () => (
-    <Can I="write" a="circles" passThrough>
+    <Can I="write" a="circles" isDisabled={!circle?.id} passThrough>
       <ButtonRounded
         name="add"
         icon="add"
         color="dark"
         onClick={onClickCreate}
-        isDisabled={!circle?.id}
       >
         Add metrics group
       </ButtonRounded>

--- a/ui/src/modules/Circles/Comparation/Item/Layer/Release.tsx
+++ b/ui/src/modules/Circles/Comparation/Item/Layer/Release.tsx
@@ -53,13 +53,12 @@ const LayerRelease = ({ circle, onClickCreate, releaseEnabled }: Props) => {
   };
 
   const renderButton = () => (
-    <Can I="write" a="deploy" passThrough>
+    <Can I="write" a="deploy" isDisabled={checkIfButtonIsDisabled()} passThrough>
         <ButtonRounded
           icon="add"
           name="add"
           color="dark"
           onClick={onClickCreate}
-          isDisabled={checkIfButtonIsDisabled()}
         >
           Insert release
         </ButtonRounded>

--- a/ui/src/modules/Circles/Comparation/Item/Layer/Segments.tsx
+++ b/ui/src/modules/Circles/Comparation/Item/Layer/Segments.tsx
@@ -96,6 +96,7 @@ const LayerSegments = ({
     ) : (
       <ButtonIconRounded
         name="add"
+        icon="add"
         color="dark"
         onClick={onClickCreate}
         isDisabled={!circle?.name}


### PR DESCRIPTION
Signed-off-by: Luane Aquino <luane.cavalcanti@zup.com.br>

## Issue Description

When creating a new circle, even if the segments are not filled, the buttons `insert release` and `add metrics group` are enabled.

## Solution

- fix button disable

### Screenshots (after):
![image](https://user-images.githubusercontent.com/74269773/126651179-e8a8d69a-f2c0-4eea-860e-bf3cdbda5bf6.png)
