### PR TITLE
make fix

### DIFF
--- a/butler/src/app/v2/api/deployments/use-cases/create-deployment.usecase.ts
+++ b/butler/src/app/v2/api/deployments/use-cases/create-deployment.usecase.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2021 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,9 +110,9 @@ export class CreateDeploymentUseCase {
     const activeComponents: ComponentEntity[] = await this.componentsRepository.findDefaultActiveComponents(
       createDeploymentDto.circle.id
     )
-    const requestedComponentsNames: string[] = this.getDeploymentRequestComponentNames(createDeploymentDto)
+    const requestedComponentIds: string[] = this.getDeploymentRequestComponentIds(createDeploymentDto)
     const unchangedComponents: ComponentEntity[] = activeComponents
-      .filter(component => !requestedComponentsNames.includes(component.name))
+      .filter(component => !requestedComponentIds.includes(component.componentId))
       .map(component => component.clone())
     this.consoleLoggerService.log('GET:UNCHANGED_DEFAULT_ACTIVE_COMPONENTS', { unchangedComponents })
     const components = await this.getDeploymentComponents(createDeploymentDto.namespace, createDeploymentDto.circle.id, createDeploymentDto.components, createDeploymentDto.git.token, createDeploymentDto.git.provider)
@@ -168,7 +168,7 @@ export class CreateDeploymentUseCase {
     return execution
   }
 
-  private getDeploymentRequestComponentNames(createDeploymentDto: CreateDeploymentRequestDto): string[] {
-    return createDeploymentDto.components.flatMap(c => c.componentName)
+  private getDeploymentRequestComponentIds(createDeploymentDto: CreateDeploymentRequestDto): string[] {
+    return createDeploymentDto.components.flatMap(c => c.componentId)
   }
 }

--- a/butler/src/tests/v2/integration/use-cases/create-deployment-usecase.integration-spec.ts
+++ b/butler/src/tests/v2/integration/use-cases/create-deployment-usecase.integration-spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2021 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ BSAwlmwpOpK27k2yXj4g1x2VaF9GGl//Ere+xUY=
           'v1',
           'https://repository.com/A:v1',
           'A',
-          'f1c95177-438c-4c4f-94fd-c207e8d2eb61',
+          '777765f8-bb29-49f7-bf2b-3ec956a71583',
           null,
           null,
           getSimpleManifests('A', 'my-namespace', 'imageurl.com')
@@ -234,5 +234,84 @@ BSAwlmwpOpK27k2yXj4g1x2VaF9GGl//Ere+xUY=
       await manager.findOneOrFail(DeploymentEntity, { relations: ['components'], where: { id: createDeploymentRequest.deploymentId } })
 
     expect(newDeployment.components).toEqual(expectedDeploymentComponents)
+  })
+
+
+  it('should not merge components with same ids and different names', async() => {
+    const encryptedToken = `-----BEGIN PGP MESSAGE-----
+
+ww0ECQMCcRYScW+NJZZy0kUBbjTidEUAU0cTcHycJ5Phx74jvSTZ7ZE7hxK9AejbNDe5jDRGbqSd
+BSAwlmwpOpK27k2yXj4g1x2VaF9GGl//Ere+xUY=
+=QGZf
+-----END PGP MESSAGE-----
+`
+    const base64Token = Buffer.from(encryptedToken).toString('base64')
+    const createDeploymentRequest = {
+      deploymentId: '28a3f957-3702-4c4e-8d92-015939f39cf2',
+      circle: {
+        id: 'f5d23a57-5607-4306-9993-477e1598cc2a',
+        default: true
+      },
+      git: {
+        token: base64Token,
+        provider: GitProvidersEnum.GITHUB
+      },
+      components: [
+        {
+          helmRepository: UrlConstants.helmRepository,
+          componentId: '777765f8-bb29-49f7-bf2b-3ec956a71583',
+          buildImageUrl: 'imageurl.com',
+          buildImageTag: 'tag-example',
+          componentName: 'A'
+        }
+      ],
+      authorId: '580a7726-a274-4fc3-9ec1-44e3563d58af',
+      callbackUrl: UrlConstants.deploymentCallbackUrl,
+      namespace: 'my-namespace'
+    }
+
+    const expectedDeploymentComponent = new ComponentEntity(
+      UrlConstants.helmRepository,
+      'tag-example',
+      'imageurl.com',
+      'new-A',
+      createDeploymentRequest.components[0].componentId,
+      null,
+      null,
+      getSimpleManifests('A', 'my-namespace', 'imageurl.com')
+    )
+    expectedDeploymentComponent.running = false
+    expectedDeploymentComponent.merged = false
+
+
+    const sameCircleActiveDeployment: DeploymentEntity = new DeploymentEntity(
+      'baa226a2-97f1-4e1b-b05a-d758839408f9',
+      'user-1',
+      createDeploymentRequest.circle.id,
+      'http://localhost:1234/notifications/deployment?deploymentId=1',
+      [
+        expectedDeploymentComponent
+      ],
+      true,
+      'my-namespace',
+      60
+    )
+
+    sameCircleActiveDeployment.current = true
+
+
+    await manager.save(sameCircleActiveDeployment)
+
+    await request(app.getHttpServer())
+      .post('/v2/deployments')
+      .send(createDeploymentRequest)
+      .set('x-circle-id', 'a45fd548-0082-4021-ba80-a50703c44a3b')
+      .expect(201)
+
+    const newDeployment =
+            await manager.findOneOrFail(DeploymentEntity, { relations: ['components'], where: { id: createDeploymentRequest.deploymentId } })
+
+    expect(newDeployment.components.length).toEqual(1)
+    expect(newDeployment.components[0].componentId).toEqual(expectedDeploymentComponent.componentId)
   })
 })


### PR DESCRIPTION
Signed-off-by: thalles <thalles.freitas@zup.com.br>

## Issue Description
When the component name of a deployment was edited, a new deployment was duplicating the pods on a override

## Solution
Use component ids instead of names on override logic
