### PR TITLE
updating spring boot version because jackson databind version flaw

### DIFF
--- a/moove/pom.xml
+++ b/moove/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.2.6.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -69,7 +69,6 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-okhttp</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>


### PR DESCRIPTION
A flaw was discovered in jackson-databind in versions before 2.9.10, 2.8.11.5 and 2.6.7.3, where it would permit polymorphic deserialization of a malicious object using commons-configuration 1 and 2 JNDI classes. An attacker could use this flaw to execute arbitrary code. Installed Version: "2.9.9", Update to Version: "2.9.10, 2.8.11.5, 2.6.7.3" for fix this issue

Signed-off-by: barbararochazup <barbara.rocha@zup.com.br>

