### PR TITLE
fixing duplicated circle code msg

### DIFF
--- a/moove/domain/src/main/kotlin/io/charlescd/moove/domain/MooveErrorCode.kt
+++ b/moove/domain/src/main/kotlin/io/charlescd/moove/domain/MooveErrorCode.kt
@@ -69,5 +69,5 @@ enum class MooveErrorCode(val key: String) {
     DEPLOYMENT_CONFIGURATION_ALREADY_REGISTERED("deployment.configuration.already.registered"),
     ACTIVE_DEPLOYMENT_NAMESPACE_ERROR("active.deployment.namespace.error"),
     DUPLICATED_WORKSPACE_NAME_ERROR("duplicated.workspace.name.error"),
-    DUPLICATED_CIRCLE_NAME_ERROR("duplicated.circe.name.error")
+    DUPLICATED_CIRCLE_NAME_ERROR("duplicated.circle.name.error")
 }


### PR DESCRIPTION
Signed-off-by: barbararochazup <barbara.rocha@zup.com.br>

## Issue Description

Error 500 on moove service when register a new circle with name of a already registered circle.

## Solution

Fix message properties on MooveErrorCode mapping

## Results

moove service returns a 422 with message 'You can not save two circles with the same name.'

