### PR TITLE
Remove notification of renovate issues

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   issue:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.issue.pull_request }}
+    if: ${{ !github.event.issue.pull_request && !github.event.issue.user.login === 'renovate[bot]' }}}}
     steps:
     - name: Git Issue Details
       run: |

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   issue:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.issue.pull_request && !github.event.issue.user.login === 'renovate[bot]' }}}}
+    if: ${{ !github.event.issue.pull_request && !github.event.issue.user.login === 'renovate[bot]' }}
     steps:
     - name: Git Issue Details
       run: |


### PR DESCRIPTION
Signed-off-by: Thalles Freitas <thalles.freitas@zup.com.br>

## Issue Description
Notification of renovate issues is not necessary

## Solution
Notify on google chat only for issues not related with renovate

