### PR TITLE
Ingress bug fix

### DIFF
--- a/install/helm-chart/Chart.lock
+++ b/install/helm-chart/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 10.3.1
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 3.15.2
+  version: 4.0.13
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 8.12.2
-digest: sha256:66a4ee63d1b8265d8708f6b1275d067da1a78e91a96f156b5b6f7f6c8e07bc8d
-generated: "2021-05-07T14:43:30.52428973-03:00"
+digest: sha256:0861f0271c2178facc186dc8407a0ad319bbc055892fa5b8822b0ef3e2021693
+generated: "2022-01-19T09:34:30.571369732-03:00"

--- a/install/helm-chart/Chart.yaml
+++ b/install/helm-chart/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
     repository: https://codecentric.github.io/helm-charts
     condition: keycloak.enabled
   - name: ingress-nginx
-    version: 3.15.2
+    version: 4.0.13
     repository: https://kubernetes.github.io/ingress-nginx
     condition: nginx_ingress_controller.enabled
   - name: rabbitmq

--- a/install/helm-chart/Chart.yaml
+++ b/install/helm-chart/Chart.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 apiVersion: v2
 name: charlescd
 description: A Helm chart for Kubernetes

--- a/install/helm-chart/templates/ingress.yaml
+++ b/install/helm-chart/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -14,7 +14,10 @@ spec:
     http:
       paths:
       - path: /(.*)
+        pathType: ImplementationSpecific
         backend:
-          serviceName: envoy-proxy
-          servicePort: 80
+          service:
+            name: envoy-proxy
+            port:
+              number: 80
 {{- end}}

--- a/install/helm-chart/templates/ingress.yaml
+++ b/install/helm-chart/templates/ingress.yaml
@@ -1,4 +1,19 @@
 {{ if .Values.ingress.enabled }}
+  #
+  # Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #  http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+#
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
## Issue Description
Ingress apiVersion networking.k8s.io/v1beta1 is no longer serverd on kubernetes version above 1.22.
#1524

## Solution
Upgrade ingress resource to use apiVersion networking.k8s.io/v1

